### PR TITLE
Update tokio-tungstenite to version 0.26.1

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ freenet-macros = { path = "../rust-macros", version = "0.1.0-rc1" }
 
 [target.'cfg(any(unix, windows))'.dependencies]
 tokio = { version = "1", optional = true, features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
-tokio-tungstenite = { version = "0.24", optional = true }
+tokio-tungstenite = { version = "0.26.1", optional = true }
 serde_with = { version = "3" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/rust/src/client_api/regular.rs
+++ b/rust/src/client_api/regular.rs
@@ -6,7 +6,6 @@ use tokio::{
     sync::mpsc::{self, Receiver, Sender},
 };
 use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
-
 use super::{
     client_events::{ClientError, ClientRequest, ErrorKind},
     Error, HostResult,
@@ -163,7 +162,7 @@ async fn process_request(
     let msg = bincode::serialize(&req)
         .map_err(Into::into)
         .map_err(Error::OtherError)?;
-    conn.send(Message::Binary(msg)).await?;
+    conn.send(Message::Binary(msg.into())).await?;
     Ok(())
 }
 
@@ -183,7 +182,7 @@ async fn process_response(
                 .map_err(|_| Error::ChannelClosed)?;
         }
         Message::Binary(binary) => {
-            let response: HostResult = bincode::deserialize(binary.as_slice())?;
+            let response: HostResult = bincode::deserialize(&binary)?;
             response_tx
                 .send(response)
                 .await
@@ -233,7 +232,7 @@ mod test {
             if !self.recv {
                 let res: HostResult = Ok(HostResponse::Ok);
                 let req = bincode::serialize(&res)?;
-                stream.send(Message::Binary(req)).await?;
+                stream.send(Message::Binary(req.into())).await?;
             }
 
             let Message::Binary(msg) = stream.next().await.ok_or_else(|| "no msg".to_owned())??

--- a/rust/src/client_api/regular.rs
+++ b/rust/src/client_api/regular.rs
@@ -1,15 +1,15 @@
 use std::{borrow::Cow, task::Poll};
 
+use super::{
+    client_events::{ClientError, ClientRequest, ErrorKind},
+    Error, HostResult,
+};
 use futures::{pin_mut, FutureExt, Sink, SinkExt, Stream, StreamExt};
 use tokio::{
     net::TcpStream,
     sync::mpsc::{self, Receiver, Sender},
 };
 use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
-use super::{
-    client_events::{ClientError, ClientRequest, ErrorKind},
-    Error, HostResult,
-};
 
 type Connection = WebSocketStream<MaybeTlsStream<TcpStream>>;
 


### PR DESCRIPTION
This pull request includes several updates and improvements to the `rust` codebase, primarily focusing on dependency updates and minor code optimizations.

Dependency updates:

* [`rust/Cargo.toml`](diffhunk://#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7L35-R35): Updated the `tokio-tungstenite` dependency version from `0.24` to `0.26.1`.

Code optimizations:

* [`rust/src/client_api/regular.rs`](diffhunk://#diff-3a675ea17fa7b48f2948cbbd8563561348f780f582ce81859a7b171c19bf4228L186-R185): Replaced `binary.as_slice()` with `&binary` in the `process_response` function to simplify the deserialization call.
* [`rust/src/client_api/regular.rs`](diffhunk://#diff-3a675ea17fa7b48f2948cbbd8563561348f780f582ce81859a7b171c19bf4228L166-R165): Used `msg.into()` instead of `msg` in the `process_request` function and a test case to improve code readability and performance. [[1]](diffhunk://#diff-3a675ea17fa7b48f2948cbbd8563561348f780f582ce81859a7b171c19bf4228L166-R165) [[2]](diffhunk://#diff-3a675ea17fa7b48f2948cbbd8563561348f780f582ce81859a7b171c19bf4228L236-R235)

Code cleanup:

* [`rust/src/client_api/regular.rs`](diffhunk://#diff-3a675ea17fa7b48f2948cbbd8563561348f780f582ce81859a7b171c19bf4228L9): Removed an unnecessary blank line after the `use tokio_tungstenite` statement.