### PR TITLE
fix clippy warns

### DIFF
--- a/rust/src/contract_interface.rs
+++ b/rust/src/contract_interface.rs
@@ -1903,9 +1903,7 @@ pub mod encoding {
                 .map(|s| <<T as EncodingAdapter>::SelfEncoder>::deserialize(s.as_ref()))
                 .transpose()?;
             let delta = delta
-                .map(|d| {
-                    <<T as EncodingAdapter>::DeltaEncoder>::deserialize(d.as_ref()).map(Into::into)
-                })
+                .map(|d| <<T as EncodingAdapter>::DeltaEncoder>::deserialize(d.as_ref()))
                 .transpose()?;
             let typed_update = TypedUpdateData::try_from((state, delta))?;
             match typed_state.merge(&typed_params, typed_update, &related_container) {


### PR DESCRIPTION
This pull request includes changes to the `rust/src/contract_interface.rs` file to simplify the deserialization process for delta encoding.

Codebase simplification:

* [`rust/src/contract_interface.rs`](diffhunk://#diff-b41c980458c554a9fe11ff75f16fe4502857622c9ab111e1665e856cc7a7217eL1906-R1906): Removed the unnecessary `map(Into::into)` call in the deserialization of delta encoding to streamline the deserialization process.