### PR TITLE
Add new fields

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 rust-version = "1.71.1"
 publish = true

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -760,7 +760,8 @@ pub struct NodeDiagnosticsResponse {
 pub struct NodeInfo {
     pub peer_id: String,
     pub is_gateway: bool,
-    pub location: String,
+    pub location: Option<String>,
+    pub listening_address: Option<String>,
     pub uptime_seconds: u64,
 }
 


### PR DESCRIPTION
This pull request includes updates to the `freenet-stdlib` package version and modifications to the `NodeInfo` struct in the `client_events.rs` file to enhance flexibility in representing node information.

Version update:

* [`rust/Cargo.toml`](diffhunk://#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7L3-R3): Updated the package version from `0.1.10` to `0.1.11` to reflect the latest changes.

Enhancements to `NodeInfo` struct:

* [`rust/src/client_api/client_events.rs`](diffhunk://#diff-404f8d3632e6ece5fbc2e4301fabc9ad4aba2ab359989711e3e4a44698c9d8feL763-R764): Changed the `location` field in the `NodeInfo` struct to `Option<String>` to allow for cases where location data might be unavailable. Added a new `listening_address` field as `Option<String>` to capture optional node listening address information.