### PR TITLE
chore: update dependencies for rand 0.9 and tokio-tungstenite 0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.14] - 2025-09-04
+
+### Changed
+- Updated `tokio-tungstenite` from 0.26.1 to 0.27.0
+- Updated `rand` from 0.8 to 0.9 (dev dependency)
+- Fixed `from_entropy()` to use `from_os_rng()` for rand 0.9 compatibility
+
+### Note
+- [AI-assisted debugging and comment]
+- This release updates dependencies to support freenet-core dependency updates
+
 ## [0.1.9] - 2025-06-19
 
 ### Added

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 rust-version = "1.71.1"
 publish = true
@@ -32,7 +32,7 @@ freenet-macros = { path = "../rust-macros", version = "0.1.0-rc1" }
 
 [target.'cfg(any(unix, windows))'.dependencies]
 tokio = { version = "1", optional = true, features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
-tokio-tungstenite = { version = "0.26.1", optional = true }
+tokio-tungstenite = { version = "0.27.0", optional = true }
 serde_with = { version = "3" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
@@ -59,7 +59,7 @@ optional = true
 [target.'cfg(any(unix, windows))'.dev-dependencies]
 bincode = "1"
 wasmer = { version = "5.0.4", features = [ "sys-default"] }
-rand = { version = "0.8", features = ["small_rng"] }
+rand = { version = "0.9", features = ["small_rng"] }
 arbitrary = { version = "1", features = ["derive"] }
 
 [features]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.71.1"
 publish = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.1.9"
+version = "0.1.12"
 edition = "2021"
 rust-version = "1.71.1"
 publish = true

--- a/rust/src/contract_interface.rs
+++ b/rust/src/contract_interface.rs
@@ -1558,7 +1558,7 @@ mod test {
 
     static RND_BYTES: Lazy<[u8; 1024]> = Lazy::new(|| {
         let mut bytes = [0; 1024];
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         rng.fill(&mut bytes);
         bytes
     });


### PR DESCRIPTION
[AI-assisted debugging and comment]

## Summary
Updates dependencies to enable freenet-core to update rand and tokio-tungstenite.

## Changes
- Update tokio-tungstenite from 0.26.1 to 0.27.0
- Update rand from 0.8 to 0.9 (dev dependency)
- Replace from_entropy() with from_os_rng() for rand 0.9 compatibility
- Bump version to 0.1.14

## Testing
- ✅ Builds successfully with all features
- ✅ Release build completes without errors

This is needed to unblock dependabot PRs in freenet-core.