### PR TITLE
feat!: add MessageOrigin::Delegate variant for inter-delegate caller attestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.5.0] - 2026-04-13
+
+### Added
+- `MessageOrigin::Delegate(DelegateKey)` variant so the runtime can attest the
+  caller's identity for delegate-to-delegate `SendDelegateMessage` calls.
+  Previously the receiver got `origin = None` and could not learn which
+  delegate invoked it. (freenet/freenet-core#3860)
+
+### Changed
+- `MessageOrigin` is now `#[non_exhaustive]`. Source code matching on it must
+  add a wildcard arm; this is a one-time source break, not a wire-format
+  break — bincode discriminants for existing variants are unchanged, so
+  deployed delegate WASM continues to deserialize `WebApp(..)` and `None`
+  origins identically.
+
+### Compatibility
+- Wire format for `MessageOrigin::WebApp(..)` is byte-identical to 0.4.x.
+- Deployed delegates only break if they start receiving inter-delegate calls
+  carrying the new `Delegate(..)` variant, which no production delegate
+  exercises today. Rebuild against 0.5.x is only required for delegates that
+  will participate in delegate-to-delegate messaging.
+
 ## [0.1.14] - 2025-09-04
 
 ### Changed

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/rust/src/delegate_interface.rs
+++ b/rust/src/delegate_interface.rs
@@ -367,12 +367,25 @@ impl<'a> TryFromFbs<&FbsSecretsId<'a>> for SecretsId {
 ///
 /// When a web app sends a message to a delegate through the WebSocket API with
 /// an authentication token, the runtime resolves the token to the originating
-/// contract and wraps it in `MessageOrigin::WebApp`. Delegates receive this as
-/// the `origin` parameter of [`DelegateInterface::process`].
+/// contract and wraps it in `MessageOrigin::WebApp`. When one delegate sends a
+/// message to another via [`OutboundDelegateMsg::SendDelegateMessage`], the
+/// runtime attests the caller's identity in `MessageOrigin::Delegate`.
+/// Delegates receive this as the `origin` parameter of
+/// [`DelegateInterface::process`].
+///
+/// This enum is `#[non_exhaustive]`: downstream code matching on it must
+/// include a wildcard arm so future variants can be added without a
+/// source-level breaking change.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum MessageOrigin {
     /// The message was sent by a web application backed by the given contract.
     WebApp(ContractInstanceId),
+    /// The message was sent by another delegate via
+    /// [`OutboundDelegateMsg::SendDelegateMessage`]. The carried key is the
+    /// runtime-attested identity of the calling delegate; the receiver can
+    /// trust it to make authorization decisions.
+    Delegate(DelegateKey),
 }
 
 /// A Delegate is a webassembly code designed to act as an agent for the user on
@@ -1113,6 +1126,46 @@ pub(crate) mod wasm_interface {
                 ptr: ptr as i64,
                 size,
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod message_origin_tests {
+    use super::*;
+
+    /// Wire-format pin: bincode encoding of `MessageOrigin::WebApp(..)` must
+    /// stay byte-identical across stdlib releases. Deployed delegate WASM
+    /// compiled against an older stdlib will receive these bytes from a
+    /// host running the new stdlib and must continue to deserialize them.
+    /// If this test ever fails, it is a wire-format break and is NOT
+    /// publishable as a non-major bump.
+    #[test]
+    fn webapp_origin_wire_format_is_stable() {
+        let id = ContractInstanceId::new([0xABu8; 32]);
+        let origin = MessageOrigin::WebApp(id);
+        let encoded = bincode::serialize(&origin).unwrap();
+
+        // Variant tag 0 (4-byte LE u32 in default bincode config) followed by
+        // the 32 raw bytes of the ContractInstanceId.
+        let mut expected = vec![0u8, 0, 0, 0];
+        expected.extend_from_slice(&[0xABu8; 32]);
+        assert_eq!(encoded, expected);
+    }
+
+    /// Round-trip the new variant, asserting it is distinct from `WebApp` on
+    /// the wire (so the runtime can't accidentally conflate the two).
+    #[test]
+    fn delegate_origin_round_trips_and_is_distinct() {
+        let key = DelegateKey::new([0x11u8; 32], crate::code_hash::CodeHash::new([0x22u8; 32]));
+        let origin = MessageOrigin::Delegate(key.clone());
+        let encoded = bincode::serialize(&origin).unwrap();
+        assert_eq!(encoded[..4], [1, 0, 0, 0], "Delegate variant tag must be 1");
+
+        let decoded: MessageOrigin = bincode::deserialize(&encoded).unwrap();
+        match decoded {
+            MessageOrigin::Delegate(k) => assert_eq!(k, key),
+            other => panic!("expected Delegate variant, got {other:?}"),
         }
     }
 }

--- a/rust/src/delegate_interface.rs
+++ b/rust/src/delegate_interface.rs
@@ -385,6 +385,13 @@ pub enum MessageOrigin {
     /// [`OutboundDelegateMsg::SendDelegateMessage`]. The carried key is the
     /// runtime-attested identity of the calling delegate; the receiver can
     /// trust it to make authorization decisions.
+    ///
+    /// Note: an inter-delegate message **replaces** rather than composes with
+    /// any inherited `WebApp` origin the calling delegate may itself hold.
+    /// The receiver sees only `Delegate(caller_key)` for the duration of the
+    /// call, and does not gain contract access on behalf of any web app the
+    /// caller was acting for. Authorization should be made on the calling
+    /// delegate's identity alone.
     Delegate(DelegateKey),
 }
 
@@ -1153,19 +1160,29 @@ mod message_origin_tests {
         assert_eq!(encoded, expected);
     }
 
-    /// Round-trip the new variant, asserting it is distinct from `WebApp` on
-    /// the wire (so the runtime can't accidentally conflate the two).
+    /// Wire-format pin for the `Delegate` variant. Locks the full byte
+    /// layout (variant tag + serde repr of `DelegateKey`) so that any future
+    /// change to either `DelegateKey`'s serde or the workspace bincode
+    /// config is caught loudly. If `DelegateKey`'s on-the-wire encoding
+    /// changes, deployed delegates compiled against a previous stdlib will
+    /// silently fail to deserialize inter-delegate origins — which is
+    /// exactly the failure mode this test exists to prevent.
     #[test]
-    fn delegate_origin_round_trips_and_is_distinct() {
+    fn delegate_origin_wire_format_is_stable() {
         let key = DelegateKey::new([0x11u8; 32], crate::code_hash::CodeHash::new([0x22u8; 32]));
-        let origin = MessageOrigin::Delegate(key.clone());
+        let origin = MessageOrigin::Delegate(key);
         let encoded = bincode::serialize(&origin).unwrap();
-        assert_eq!(encoded[..4], [1, 0, 0, 0], "Delegate variant tag must be 1");
 
+        // Variant tag 1 (4-byte LE u32 in default bincode config), followed
+        // by the 32-byte `key` field, followed by the 32-byte `code_hash`
+        // field of `DelegateKey`.
+        let mut expected = vec![1u8, 0, 0, 0];
+        expected.extend_from_slice(&[0x11u8; 32]);
+        expected.extend_from_slice(&[0x22u8; 32]);
+        assert_eq!(encoded, expected);
+
+        // And it must still round-trip.
         let decoded: MessageOrigin = bincode::deserialize(&encoded).unwrap();
-        match decoded {
-            MessageOrigin::Delegate(k) => assert_eq!(k, key),
-            other => panic!("expected Delegate variant, got {other:?}"),
-        }
+        assert!(matches!(decoded, MessageOrigin::Delegate(_)));
     }
 }

--- a/rust/src/memory/buf.rs
+++ b/rust/src/memory/buf.rs
@@ -652,7 +652,7 @@ mod test_streaming_read {
         let mut reader = unsafe { host_streaming_buffer(data) };
         assert_eq!(reader.total_remaining(), 10);
         let mut buf = [0u8; 4];
-        reader.read(&mut buf).unwrap();
+        reader.read_exact(&mut buf).unwrap();
         assert_eq!(reader.total_remaining(), 6);
     }
 


### PR DESCRIPTION
## Problem

When delegate A sends a message to delegate B via
`OutboundDelegateMsg::SendDelegateMessage`, B's `process()` is invoked with
`origin = None`. B has no way to learn which delegate (if any) called it,
because `MessageOrigin` only had a `WebApp(ContractInstanceId)` variant. This
blocks any trust policy that depends on caller delegate identity, and prevents
permission prompts from showing the actual caller for delegate-to-delegate
`RequestUserInput` requests (see freenet/freenet-core#3857).

## Approach

Add `MessageOrigin::Delegate(DelegateKey)` so the runtime can attest the
calling delegate's identity. The companion freenet-core PR plumbs this
through the executor at `contract.rs:479` so inter-delegate dispatch passes
`Some(MessageOrigin::Delegate(caller_key))` instead of `None`.

Mark `MessageOrigin` as `#[non_exhaustive]` in the same change so future
variants can be added without a source-level break. This is a one-time source
break for downstream code that currently matches the enum exhaustively — they
must add a wildcard arm.

## Compatibility

This is a **source-level** breaking change (variant added + `non_exhaustive`),
hence the major-bump 0.4.0 → **0.5.0**. It is **not** a wire-format break:

- The bincode discriminant for `MessageOrigin::WebApp(..)` is unchanged
  (variant index 0). Deployed delegate WASM compiled against 0.4.x will
  continue to deserialize `WebApp(..)` and `None` origins identically. A new
  wire-format pin test (`webapp_origin_wire_format_is_stable`) locks the
  byte layout.
- Old delegate WASM only fails if it starts receiving an inbound
  `MessageOrigin::Delegate(..)`. That requires another delegate to call it
  via `SendDelegateMessage`, which no production delegate exercises today
  (river chat delegate, ghostkey, etc. do not participate in inter-delegate
  messaging).
- Adding `#[non_exhaustive]` does not affect runtime/wire behavior — it only
  changes how source code may match on the enum.

So in practice: contracts are unaffected entirely (`MessageOrigin` is
delegate-only); deployed delegates are unaffected unless they begin
participating in inter-delegate messaging; downstream code that builds
against 0.5.x and pattern-matches on `MessageOrigin` must add a wildcard arm.

## Testing

- `webapp_origin_wire_format_is_stable` — pins the bincode bytes for
  `WebApp(..)` so any future refactor that changes the wire format will fail
  loudly. Wire-format breaks at this layer would break every deployed
  delegate, so this test is the canary.
- `delegate_origin_round_trips_and_is_distinct` — round-trips the new
  `Delegate(..)` variant and asserts its discriminant tag is **1**, distinct
  from `WebApp(..)` so the two cannot be conflated.
- Pre-existing `delegate_interface` tests continue to pass.

Drive-by: tightened a `read()` → `read_exact()` test in `memory::buf` so
`cargo clippy --all-targets` is clean under newer stable clippy. CI only
clippies the wasm32 target so this didn't surface in CI; I tripped over it
running local `--all-targets` checks.

## Release coordination

This crate must publish to crates.io as **0.5.0** before the freenet-core PR
that consumes the new variant can merge. The freenet-core PR currently
points at this branch via a `[patch.crates-io]` override.

## Fixes

Companion to freenet/freenet-core#3860.

[AI-assisted - Claude]