### PR TITLE
feat!: harden wire-boundary enums with #[non_exhaustive] + pin tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.6.0] - 2026-04-13
+
+### Changed (source-level breaking, wire-compatible)
+- Added `#[non_exhaustive]` to five wire-boundary enums so future variants
+  can be added without a source-level break for downstream consumers that
+  match exhaustively:
+  - `delegate_interface::InboundDelegateMsg` (companion to the already-
+    `non_exhaustive` `OutboundDelegateMsg`)
+  - `contract_interface::update::UpdateData`
+  - `delegate_interface::DelegateError`
+  - `contract_interface::error::ContractError`
+  - `versioning::APIVersion`
+  Downstream `match` sites must now include a wildcard arm.
+
+### Added
+- Wire-format pin tests for `InboundDelegateMsg::ApplicationMessage` and
+  `UpdateData::{State, Delta}`. These lock the bincode variant tags so that
+  a refactor which reorders variants fails loudly at test time rather than
+  silently corrupting in-flight messages to deployed contracts/delegates.
+
+### Compatibility
+- `#[non_exhaustive]` is a source-level change only. It does not affect
+  bincode discriminants, serde `Serialize`/`Deserialize` impls, byte layout,
+  or the wire format. Deployed contracts and delegates compiled against any
+  previous 0.x stdlib continue to deserialize identically. This bump is
+  minor-breaking (0.5.0 → 0.6.0) only because downstream Rust code that
+  pattern-matches these enums exhaustively must add a wildcard arm to
+  compile against 0.6.
+
 ## [0.5.0] - 2026-04-13
 
 ### Added

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/rust/src/contract_interface/error.rs
+++ b/rust/src/contract_interface/error.rs
@@ -3,6 +3,10 @@
 use serde::{Deserialize, Serialize};
 
 /// Type of errors during interaction with a contract.
+///
+/// Marked `#[non_exhaustive]` so future error variants can be added without
+/// a source-level break. Downstream `match` sites must include a wildcard arm.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error, Serialize, Deserialize)]
 pub enum ContractError {
     #[error("de/serialization error: {0}")]

--- a/rust/src/contract_interface/update.rs
+++ b/rust/src/contract_interface/update.rs
@@ -181,6 +181,12 @@ pub enum ValidateResult {
 }
 
 /// Update notifications for a contract or a related contract.
+///
+/// This sits on the contract-update wire boundary. Marked `#[non_exhaustive]`
+/// so future variants (for example, new `Related*` shapes) can be added
+/// without a source-level break; downstream `match` sites must include a
+/// wildcard arm. Wire format is pinned by `update_data_wire_format_is_stable`.
+#[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum UpdateData<'a> {
     State(#[serde(borrow)] State<'a>),
@@ -341,5 +347,43 @@ impl<'a> TryFromFbs<&FbsUpdateData<'a>> for UpdateData<'a> {
             }
             _ => unreachable!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod update_data_wire_format_tests {
+    use super::*;
+
+    /// Wire-format pin for [`UpdateData`]. Variant ordering is a wire
+    /// contract: deployed contracts compiled against an older stdlib
+    /// deserialize `UpdateData` by positional tag, so reordering the
+    /// existing variants would silently route incoming state updates
+    /// into the wrong arm. This test locks the tag for `State(..)` at 0
+    /// and `Delta(..)` at 1. Adding a new variant at the end is
+    /// compatible; inserting or reordering existing variants is a
+    /// wire-format break and must trip this test.
+    #[test]
+    fn update_data_wire_format_is_stable() {
+        let state = UpdateData::State(State::from(vec![0xAA, 0xBB]));
+        let state_bytes = bincode::serialize(&state).unwrap();
+        assert_eq!(
+            state_bytes[..4],
+            [0, 0, 0, 0],
+            "UpdateData::State must stay at variant tag 0"
+        );
+
+        let delta = UpdateData::Delta(StateDelta::from(vec![0xCC, 0xDD]));
+        let delta_bytes = bincode::serialize(&delta).unwrap();
+        assert_eq!(
+            delta_bytes[..4],
+            [1, 0, 0, 0],
+            "UpdateData::Delta must stay at variant tag 1"
+        );
+
+        // Round-trip both.
+        let decoded_state: UpdateData<'_> = bincode::deserialize(&state_bytes).unwrap();
+        assert!(matches!(decoded_state, UpdateData::State(_)));
+        let decoded_delta: UpdateData<'_> = bincode::deserialize(&delta_bytes).unwrap();
+        assert!(matches!(decoded_delta, UpdateData::Delta(_)));
     }
 }

--- a/rust/src/delegate_interface.rs
+++ b/rust/src/delegate_interface.rs
@@ -288,6 +288,10 @@ impl<'a> TryFromFbs<&FbsDelegateKey<'a>> for DelegateKey {
 }
 
 /// Type of errors during interaction with a delegate.
+///
+/// Marked `#[non_exhaustive]` so future error variants can be added without a
+/// source-level break. Downstream `match` sites must include a wildcard arm.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error, Serialize, Deserialize)]
 pub enum DelegateError {
     #[error("de/serialization error: {0}")]
@@ -487,6 +491,18 @@ impl AsRef<[u8]> for DelegateContext {
     }
 }
 
+/// Messages delivered **into** a delegate's `process()` function.
+///
+/// This is the inbound counterpart of [`OutboundDelegateMsg`] and sits on the
+/// host↔delegate wire boundary. Marked `#[non_exhaustive]` so future variants
+/// can be added without a source-level break; downstream `match` sites must
+/// include a wildcard arm. This matches the pre-existing `#[non_exhaustive]`
+/// on `OutboundDelegateMsg`.
+///
+/// Wire format: bincode with variant index 0..=N in declaration order. The
+/// `inbound_delegate_msg_wire_format_is_stable` test pins the bytes for
+/// `ApplicationMessage(..)` so that refactors cannot silently shift the tag.
+#[non_exhaustive]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InboundDelegateMsg<'a> {
     ApplicationMessage(ApplicationMessage),
@@ -1184,5 +1200,27 @@ mod message_origin_tests {
         // And it must still round-trip.
         let decoded: MessageOrigin = bincode::deserialize(&encoded).unwrap();
         assert!(matches!(decoded, MessageOrigin::Delegate(_)));
+    }
+
+    /// Wire-format pin for the first variant of [`InboundDelegateMsg`]. Pins
+    /// the tag so that reordering the enum cannot silently shift existing
+    /// deployed delegate WASM off the correct variant. Only tag+payload
+    /// prefix is asserted (not the full ApplicationMessage byte layout),
+    /// since ApplicationMessage's internal fields have their own stability
+    /// expectations handled at a different layer. What matters here is that
+    /// variant 0 stays `ApplicationMessage` on the wire.
+    #[test]
+    fn inbound_delegate_msg_wire_format_is_stable() {
+        let msg = InboundDelegateMsg::ApplicationMessage(ApplicationMessage::new(vec![0xCC]));
+        let encoded = bincode::serialize(&msg).unwrap();
+        assert_eq!(
+            encoded[..4],
+            [0, 0, 0, 0],
+            "ApplicationMessage must stay at variant tag 0 on the wire; \
+             reordering InboundDelegateMsg variants is a wire-format break"
+        );
+        // And it must still round-trip into the same variant.
+        let decoded: InboundDelegateMsg<'_> = bincode::deserialize(&encoded).unwrap();
+        assert!(matches!(decoded, InboundDelegateMsg::ApplicationMessage(_)));
     }
 }

--- a/rust/src/versioning.rs
+++ b/rust/src/versioning.rs
@@ -352,6 +352,12 @@ pub enum VersionError {
     IoError(#[from] std::io::Error),
 }
 
+/// Marked `#[non_exhaustive]` so future protocol versions can be added
+/// without a source-level break. Downstream `match` sites must include a
+/// wildcard arm. Historical note: an earlier release had `APIVersion::from_u64`
+/// panic on unknown versions; both the panic fix (0.1.8) and this attribute
+/// reduce the blast radius of version evolution.
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum APIVersion {
     Version0_0_1,


### PR DESCRIPTION
## Problem

freenet-stdlib repeatedly hits source-level breakage cycles when wire-boundary enums grow new variants (most recently #65 / freenet/freenet-core#3860 for `MessageOrigin`, the v0.2.11 streaming incident for `HostResponse`, etc.). Each break forces every downstream consumer that pattern-matches exhaustively to add a wildcard arm — a coordination tax that this PR pays once for five enums at once so future variants are non-events at the source level.

A separate failure mode: a refactor that innocently reorders enum variants would silently rewrite the bincode wire tags and break every deployed consumer without a compile error. There is no regression guard for that today on any enum except `MessageOrigin` (added in 0.5.0).

## Approach

Add `#[non_exhaustive]` to the five wire-boundary enums that don't already have it:

- `delegate_interface::InboundDelegateMsg` (companion to `OutboundDelegateMsg`)
- `contract_interface::update::UpdateData`
- `delegate_interface::DelegateError`
- `contract_interface::error::ContractError`
- `versioning::APIVersion`

Add wire-format pin tests for two of them mirroring the `MessageOrigin` pattern from 0.5.0:

- `inbound_delegate_msg_wire_format_is_stable` — asserts `ApplicationMessage(..)` stays at variant tag 0 and round-trips
- `update_data_wire_format_is_stable` — asserts `State(..)` at tag 0 and `Delta(..)` at tag 1 and round-trips both

## Compatibility

Source-level breaking, **wire-compatible**:

- `#[non_exhaustive]` is a source attribute only. No effect on bincode discriminants, serde impls, byte layout, or wire format.
- Deployed contract/delegate WASM compiled against any earlier 0.x stdlib continues to deserialize identically. The wire format is unchanged byte-for-byte (which is what the new pin tests now permanently lock down).
- Downstream **Rust** code that pattern-matches these enums exhaustively must add a wildcard arm to compile against 0.6. Per investigation, the only current consumer of stdlib 0.5.0 is freenet-core itself, which is updated in the companion freenet/freenet-core#3865. River and delta are pinned to 0.3.5 and unaffected until they voluntarily bump.

Bumps 0.5.0 → 0.6.0 (minor-breaking per 0.x semver).

## Testing

- Existing `webapp_origin_wire_format_is_stable` and `delegate_origin_wire_format_is_stable` pin tests continue to pass.
- New: `inbound_delegate_msg_wire_format_is_stable`, `update_data_wire_format_is_stable`.
- `cargo test` full sweep clean.
- `cargo clippy --all-targets --all-features` clean (only the pre-existing `__frnt__fill_buffer` snake-case warning unrelated to this PR).

## Release coordination

This unblocks the second hardening pass on freenet/freenet-core#3865 (which folds the dep bump and any required wildcard arms into the same PR rollout, per the "fold-into-#3865" decision).

[AI-assisted - Claude]