### PR TITLE
ci: add tag-triggered release workflow for ts and rust crates

### DIFF
--- a/.claude/skills/release-rust/SKILL.md
+++ b/.claude/skills/release-rust/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: release-rust
+description: Release the freenet-stdlib and/or freenet-macros Rust crates to crates.io. Use when the user says "release the rust crate", "publish freenet-stdlib to crates.io", "cut a rust release", "bump and publish rust", "release freenet-macros", or similar. Can run locally via scripts/release-rust-ver.sh or remotely via the Release workflow on a pushed tag.
+---
+
+# Release freenet-stdlib / freenet-macros
+
+Two crates live in this repo:
+- `freenet-stdlib` at `rust/Cargo.toml`
+- `freenet-macros` at `rust-macros/Cargo.toml`
+
+Target registry: crates.io. Auth: `CARGO_REGISTRY_TOKEN` (local) or GitHub secret `CARGO_REGISTRY_TOKEN` (CI).
+
+## Two release paths
+
+### Path A — CI (preferred)
+
+1. Bump version(s) in Cargo.toml.
+2. Open PR, merge to main.
+3. Tag and push:
+   - `rust-v<version>` → publishes `freenet-stdlib`
+   - `rust-macros-v<version>` → publishes `freenet-macros`
+4. `.github/workflows/release.yml` runs: verifies tag matches Cargo.toml version, dry-runs, then `cargo publish`.
+
+If releasing both, tag macros first (stdlib depends on it) and wait for publish before tagging stdlib.
+
+### Path B — Local
+
+```
+bash scripts/release-rust-ver.sh [--yes] [--skip-macros] [--skip-stdlib]
+```
+
+Flags:
+- `--yes` / `-y` — non-interactive
+- `--skip-macros` — only publish stdlib
+- `--skip-stdlib` — only publish macros
+
+Requires `cargo login` or `CARGO_REGISTRY_TOKEN` env var in shell.
+
+## Inputs to gather
+
+1. **Which crate(s)**: stdlib, macros, or both.
+2. **Version bump**: semver. Show current version from Cargo.toml first.
+3. **Path**: CI or local.
+
+## Pre-flight
+
+- `git status` clean
+- On `main` (or deliberately on another branch)
+- `cargo publish --dry-run -p <crate>` passes
+- `cargo test --workspace` passes
+- If stdlib depends on a new macros version, macros must be published first
+- `crates.io` version does not already exist: `cargo search freenet-stdlib`
+
+## Bump + commit
+
+1. Edit `rust/Cargo.toml` or `rust-macros/Cargo.toml` `version`.
+2. If stdlib bumps its dep on macros, update that too.
+3. Commit:
+   ```
+   git add rust/Cargo.toml
+   git commit -m "chore(rust): bump freenet-stdlib to <version>"
+   ```
+
+## Tag + push (CI path)
+
+```
+git tag -a rust-v<version> -m "Release freenet-stdlib <version>"
+git push origin rust-v<version>
+```
+
+For macros: tag `rust-macros-v<version>`.
+
+Workflow verifies tag matches Cargo.toml version. Mismatch = fail-fast.
+
+## Post-publish verification
+
+- `cargo search freenet-stdlib` — should list new version
+- https://crates.io/crates/freenet-stdlib — should show new version
+- Actions tab — release workflow green
+
+## Common failures
+
+- **Tag/Cargo.toml version mismatch**: workflow fails fast. Retag after fix.
+- **Publish blocked by uncommitted files in workspace**: `cargo publish` requires clean state.
+- **Macros dep version not published yet**: publish macros first, wait for index refresh, then stdlib.
+- **`error: crate version X is already uploaded`**: version exists. Bump again.
+- **Rate limit**: crates.io throttles publishes; wait and retry.
+
+## Do not
+
+- Never `cargo yank` casually — only for critical bugs/security.
+- Never skip `--dry-run` on manual local releases.
+- Never push a tag before the bump commit is on main.
+- Never store `CARGO_REGISTRY_TOKEN` in the repo.

--- a/.claude/skills/release-typescript/SKILL.md
+++ b/.claude/skills/release-typescript/SKILL.md
@@ -5,7 +5,20 @@ description: Release the @freenetorg/freenet-stdlib npm package. Use when the us
 
 # Release @freenetorg/freenet-stdlib
 
-Release the TypeScript SDK to npm. Package: `@freenetorg/freenet-stdlib`. Registry: npmjs.org. Publish requires 2FA OTP.
+Release the TypeScript SDK to npm. Package: `@freenetorg/freenet-stdlib`. Registry: npmjs.org. Publish requires 2FA OTP or access token.
+
+## Two release paths
+
+### Path A — CI (preferred)
+
+1. Bump `typescript/package.json` version.
+2. PR → merge to main.
+3. Tag + push: `git tag -a typescript-v<version> -m "..." && git push origin typescript-v<version>`.
+4. `.github/workflows/release.yml` verifies tag matches package.json, builds, tests, packs, publishes via `NPM_TOKEN` secret.
+
+### Path B — Local (fallback)
+
+Use `scripts/release-typescript-ver.sh`. See sections below.
 
 ## Inputs to gather before starting
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "typescript-v*"
+      - "rust-v*"
+      - "rust-macros-v*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which package to release"
+        required: true
+        type: choice
+        options:
+          - typescript
+          - rust-stdlib
+          - rust-macros
+      dry_run:
+        description: "Dry run (no publish)"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release-typescript:
+    if: startsWith(github.ref, 'refs/tags/typescript-v') || (github.event_name == 'workflow_dispatch' && inputs.target == 'typescript')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify tag matches package.json
+        if: startsWith(github.ref, 'refs/tags/typescript-v')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/typescript-v}"
+          PKG_VER=$(node -p "require('./package.json').version")
+          if [[ "$TAG" != "$PKG_VER" ]]; then
+            echo "Tag version '$TAG' does not match package.json version '$PKG_VER'"
+            exit 1
+          fi
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack preview
+        run: npm pack --dry-run
+
+      - name: Publish
+        if: github.event_name == 'push' || !inputs.dry_run
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-rust-macros:
+    if: startsWith(github.ref, 'refs/tags/rust-macros-v') || (github.event_name == 'workflow_dispatch' && inputs.target == 'rust-macros')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches Cargo.toml
+        if: startsWith(github.ref, 'refs/tags/rust-macros-v')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/rust-macros-v}"
+          CRATE_VER=$(grep -m1 '^version' rust-macros/Cargo.toml | cut -d'"' -f2)
+          if [[ "$TAG" != "$CRATE_VER" ]]; then
+            echo "Tag version '$TAG' does not match Cargo.toml version '$CRATE_VER'"
+            exit 1
+          fi
+
+      - name: Publish dry-run
+        run: cargo publish --dry-run -p freenet-macros
+
+      - name: Publish
+        if: github.event_name == 'push' || !inputs.dry_run
+        run: cargo publish -p freenet-macros
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-rust-stdlib:
+    if: startsWith(github.ref, 'refs/tags/rust-v') || (github.event_name == 'workflow_dispatch' && inputs.target == 'rust-stdlib')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches Cargo.toml
+        if: startsWith(github.ref, 'refs/tags/rust-v')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/rust-v}"
+          CRATE_VER=$(grep -m1 '^version' rust/Cargo.toml | cut -d'"' -f2)
+          if [[ "$TAG" != "$CRATE_VER" ]]; then
+            echo "Tag version '$TAG' does not match Cargo.toml version '$CRATE_VER'"
+            exit 1
+          fi
+
+      - name: Publish dry-run
+        run: cargo publish --dry-run -p freenet-stdlib
+
+      - name: Publish
+        if: github.event_name == 'push' || !inputs.dry_run
+        run: cargo publish -p freenet-stdlib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that publishes on tag push:
  - `typescript-v*` → `npm publish @freenetorg/freenet-stdlib`
  - `rust-v*` → `cargo publish freenet-stdlib`
  - `rust-macros-v*` → `cargo publish freenet-macros`
- Each job verifies the tag version matches the manifest (package.json or Cargo.toml), runs tests, does a dry-run publish, then the real publish.
- Also supports `workflow_dispatch` with a `dry_run` toggle so we can exercise it without pushing a tag.
- Add `release-rust` Claude skill mirroring `release-typescript` so both flows are documented end-to-end.
- Update `release-typescript` skill to list the CI path as preferred.

## Required repo secrets

These do **not** exist yet and must be added before the workflow can publish:

| Secret | Used by | How to get |
|---|---|---|
| `NPM_TOKEN` | ts job | npmjs.com → Access Tokens → "Automation" (bypasses 2FA) |
| `CARGO_REGISTRY_TOKEN` | rust jobs | crates.io → Account Settings → API Tokens |

Without these, jobs will fail at the publish step.

## Test plan
- [x] `yaml.safe_load` parses `release.yml` cleanly
- [ ] After merge: add secrets, run `workflow_dispatch` with `dry_run=true` on each target to verify build/pack/dry-run steps pass
- [ ] Next real release: push a tag, confirm the workflow publishes