### PR TITLE
fix!: stringify NodeDiagnosticsResponse.contract_states keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed (wire-format break in `NodeDiagnosticsResponse`)
+- `NodeDiagnosticsResponse.contract_states` is now
+  `HashMap<String, ContractState>` (Base58 contract id) instead of
+  `HashMap<ContractKey, ContractState>`. The previous type had a
+  derived `Serialize` for `ContractKey` that emitted a struct
+  (`{instance, code}`), which `serde_json` rejects because JSON object
+  keys must be strings — every diagnostic report from a node hosting at
+  least one contract uploaded with empty `network_status`. The new key
+  matches the convention every other field in this struct already uses
+  (`peer_id: String`, `connected_peers: Vec<(String, String)>`,
+  `ContractHostingEntry::contract_key: String`). See
+  freenet/freenet-core#3987.
+- This is a bincode wire-format break for `NodeDiagnosticsResponse`.
+  Older clients (built against 0.6.x) that decode the
+  `HostResponse::QueryResponse(QueryResponse::NodeDiagnostics(_))`
+  variant will fail to deserialize the new payload. The only known
+  in-tree consumer is `fdev`'s diagnostics command, which is shipped
+  with `freenet-core` and rebuilt in lockstep. `freenet service report`
+  was already broken on the old shape and works with the new shape
+  via the local fix in freenet/freenet-core#3989.
+- Added a `serde_json` round-trip regression test for
+  `NodeDiagnosticsResponse` to prevent the same class of bug from
+  reappearing — any future field whose key type does not serialize as
+  a string would break this test at the source.
+
 ## [0.6.0] - 2026-04-13
 
 ### Changed (source-level breaking, wire-compatible)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.0]
 
 ### Fixed (wire-format break in `NodeDiagnosticsResponse`)
 - `NodeDiagnosticsResponse.contract_states` is now
@@ -14,18 +14,46 @@
   (`peer_id: String`, `connected_peers: Vec<(String, String)>`,
   `ContractHostingEntry::contract_key: String`). See
   freenet/freenet-core#3987.
-- This is a bincode wire-format break for `NodeDiagnosticsResponse`.
-  Older clients (built against 0.6.x) that decode the
-  `HostResponse::QueryResponse(QueryResponse::NodeDiagnostics(_))`
-  variant will fail to deserialize the new payload. The only known
-  in-tree consumer is `fdev`'s diagnostics command, which is shipped
-  with `freenet-core` and rebuilt in lockstep. `freenet service report`
-  was already broken on the old shape and works with the new shape
-  via the local fix in freenet/freenet-core#3989.
-- Added a `serde_json` round-trip regression test for
-  `NodeDiagnosticsResponse` to prevent the same class of bug from
-  reappearing — any future field whose key type does not serialize as
-  a string would break this test at the source.
+
+### Compatibility
+- This is a **bidirectional bincode wire-format break** for
+  `NodeDiagnosticsResponse`. Bincode encodes
+  `HashMap<ContractKey, ContractState>` and
+  `HashMap<String, ContractState>` as different byte sequences for the
+  same logical data, so:
+  - Older clients built against 0.6.x will fail to deserialize a
+    `HostResponse::QueryResponse(QueryResponse::NodeDiagnostics(_))`
+    payload produced by a 0.7-or-newer node.
+  - Newer clients built against 0.7.0 will fail to deserialize the same
+    variant produced by an older node.
+  Every other variant in `HostResponse`/`QueryResponse` is unchanged;
+  the `#[non_exhaustive]` enum discriminants from 0.6.0 still hold.
+  Run matched versions across gateway and tooling.
+- The Base58 stringification via `ContractKey::Display` drops the
+  `code_hash` field that the broken derived serializer would have
+  emitted alongside `instance`. No in-tree consumer reads `code_hash`
+  from this map; future consumers that need it will need a separate
+  field.
+- Known affected consumer sites that need source updates when
+  freenet-core bumps to a release including this stdlib:
+  - `crates/core/src/node/network_bridge/p2p_protoc.rs:1900,1916`
+    (producer-side: `.insert(contract_key, ...)` becomes
+    `.insert(contract_key.to_string(), ...)`)
+  - `crates/fdev/src/diagnostics.rs:158-170` (consumer-side: already
+    iterates and calls `.to_string()` on the key — source-compatible,
+    no change required)
+  - `crates/core/src/bin/commands/report.rs::diagnostics_to_json`
+    (the workaround merged in freenet/freenet-core#3989 — `.to_string()`
+    on `String` is a no-op, so still correct, but the helper becomes
+    redundant and can be simplified to a plain
+    `serde_json::to_string_pretty(&diag)`)
+  - `freenet-test-network/src/network.rs:1093` (out-of-tree consumer:
+    map lookup keyed by `ContractKey` needs `.to_string()`)
+- Added a `serde_json` round-trip regression test in stdlib for
+  `NodeDiagnosticsResponse` (every field populated) to prevent the
+  same class of bug from reappearing — any future struct field whose
+  key type does not serialize as a string would break this test at
+  the source.
 
 ## [0.6.0] - 2026-04-13
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -1745,7 +1745,11 @@ impl<T> From<ContractResponse<T>> for HostResponse<T> {
 
 #[cfg(test)]
 mod node_diagnostics_response_tests {
-    use super::{ContractState, NodeDiagnosticsResponse};
+    use super::{
+        ConnectedPeerInfo, ContractState, NetworkInfo, NodeDiagnosticsResponse, NodeInfo,
+        SubscriptionInfo, SystemMetrics,
+    };
+    use crate::contract_interface::ContractInstanceId;
     use std::collections::HashMap;
 
     /// Regression for freenet/freenet-core#3987.
@@ -1758,8 +1762,12 @@ mod node_diagnostics_response_tests {
     /// invisible until the `freenet service report` binary tried to
     /// JSON-serialize the response for upload — every report from a node
     /// hosting at least one contract uploaded with empty `network_status`.
-    /// This test pins the fix: serde_json must succeed for a populated
-    /// response, and the round-tripped key must match the input string.
+    ///
+    /// All six fields are populated so that any future `pub` field added
+    /// to the struct gets exercised by serde_json the moment a contributor
+    /// sets a non-default value here. If a future field reintroduces the
+    /// non-string-key pattern (e.g. `HashMap<PeerId, _>`), this test will
+    /// fail at the source instead of silently breaking the report path.
     #[test]
     fn node_diagnostics_response_json_round_trips() {
         let mut contract_states = HashMap::new();
@@ -1767,21 +1775,50 @@ mod node_diagnostics_response_tests {
             "6kVs66bKaQAC6ohr8b43SvJ95r36tc2hnG7HezmaJHF9".to_string(),
             ContractState {
                 subscribers: 3,
-                subscriber_peer_ids: vec!["peer-a".to_string()],
+                subscriber_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
                 size_bytes: 1024,
             },
         );
+
         let response = NodeDiagnosticsResponse {
-            node_info: None,
-            network_info: None,
-            subscriptions: vec![],
+            node_info: Some(NodeInfo {
+                peer_id: "peer-self".to_string(),
+                is_gateway: true,
+                location: Some("0.5".to_string()),
+                listening_address: Some("0.0.0.0:31337".to_string()),
+                uptime_seconds: 3600,
+            }),
+            network_info: Some(NetworkInfo {
+                connected_peers: vec![("peer-x".to_string(), "10.0.0.1:31337".to_string())],
+                active_connections: 1,
+            }),
+            subscriptions: vec![SubscriptionInfo {
+                contract_key: ContractInstanceId::new([7u8; 32]),
+                client_id: 42,
+            }],
             contract_states,
-            system_metrics: None,
-            connected_peers_detailed: vec![],
+            system_metrics: Some(SystemMetrics {
+                active_connections: 1,
+                hosting_contracts: 1,
+            }),
+            connected_peers_detailed: vec![ConnectedPeerInfo {
+                peer_id: "peer-x".to_string(),
+                address: "10.0.0.1:31337".to_string(),
+            }],
         };
 
         let json = serde_json::to_string(&response).expect("must serialize to JSON");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("output is valid JSON");
+
+        // Every top-level field is present and distinguishable.
+        let obj = parsed.as_object().expect("top-level must be object");
+        assert_eq!(obj.len(), 6, "expected six top-level fields, got {obj:?}");
+        assert_eq!(parsed["node_info"]["peer_id"], "peer-self");
+        assert_eq!(parsed["network_info"]["active_connections"], 1);
+        assert_eq!(parsed["subscriptions"][0]["client_id"], 42);
+        assert_eq!(parsed["system_metrics"]["hosting_contracts"], 1);
+        assert_eq!(parsed["connected_peers_detailed"][0]["peer_id"], "peer-x");
+
         let states = parsed["contract_states"]
             .as_object()
             .expect("contract_states must be a JSON object");
@@ -1789,6 +1826,18 @@ mod node_diagnostics_response_tests {
         assert_eq!(
             states["6kVs66bKaQAC6ohr8b43SvJ95r36tc2hnG7HezmaJHF9"]["subscribers"],
             3
+        );
+
+        // Bincode round-trip must also still work for the same value
+        // (the new wire format is the contract; older clients are
+        // documented as incompatible in CHANGELOG).
+        let bytes = bincode::serialize(&response).expect("bincode must serialize");
+        let decoded: NodeDiagnosticsResponse =
+            bincode::deserialize(&bytes).expect("bincode must round-trip");
+        assert_eq!(
+            decoded.contract_states.len(),
+            1,
+            "bincode round-trip preserves contract_states entries"
         );
     }
 }

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -799,8 +799,17 @@ pub struct NodeDiagnosticsResponse {
     /// Contract subscription information
     pub subscriptions: Vec<SubscriptionInfo>,
 
-    /// Contract states for specific contracts
-    pub contract_states: std::collections::HashMap<ContractKey, ContractState>,
+    /// Contract states for specific contracts.
+    ///
+    /// Keys are the Base58-encoded contract id (i.e. `ContractKey::Display`),
+    /// matching the convention every other field in this struct uses
+    /// (`peer_id: String`, `connected_peers: Vec<(String, String)>`,
+    /// `ContractHostingEntry::contract_key: String`). Pre-0.7 this was
+    /// `HashMap<ContractKey, ContractState>`, which `serde_json` could not
+    /// serialize because JSON object keys must be strings — every report
+    /// from a node hosting at least one contract had its
+    /// `network_status` silently dropped. See freenet/freenet-core#3987.
+    pub contract_states: std::collections::HashMap<String, ContractState>,
 
     /// System metrics
     pub system_metrics: Option<SystemMetrics>,
@@ -1731,6 +1740,56 @@ pub enum ContractResponse<T = WrappedState> {
 impl<T> From<ContractResponse<T>> for HostResponse<T> {
     fn from(value: ContractResponse<T>) -> HostResponse<T> {
         HostResponse::ContractResponse(value)
+    }
+}
+
+#[cfg(test)]
+mod node_diagnostics_response_tests {
+    use super::{ContractState, NodeDiagnosticsResponse};
+    use std::collections::HashMap;
+
+    /// Regression for freenet/freenet-core#3987.
+    ///
+    /// Pre-0.7 `contract_states` was `HashMap<ContractKey, ContractState>`.
+    /// `ContractKey` derives `Serialize` as a struct (`{instance, code}`),
+    /// which `serde_json` rejects with `key must be a string` because JSON
+    /// object keys must be strings. The wire path between core and clients
+    /// is bincode (which doesn't care about key types), so the bug stayed
+    /// invisible until the `freenet service report` binary tried to
+    /// JSON-serialize the response for upload — every report from a node
+    /// hosting at least one contract uploaded with empty `network_status`.
+    /// This test pins the fix: serde_json must succeed for a populated
+    /// response, and the round-tripped key must match the input string.
+    #[test]
+    fn node_diagnostics_response_json_round_trips() {
+        let mut contract_states = HashMap::new();
+        contract_states.insert(
+            "6kVs66bKaQAC6ohr8b43SvJ95r36tc2hnG7HezmaJHF9".to_string(),
+            ContractState {
+                subscribers: 3,
+                subscriber_peer_ids: vec!["peer-a".to_string()],
+                size_bytes: 1024,
+            },
+        );
+        let response = NodeDiagnosticsResponse {
+            node_info: None,
+            network_info: None,
+            subscriptions: vec![],
+            contract_states,
+            system_metrics: None,
+            connected_peers_detailed: vec![],
+        };
+
+        let json = serde_json::to_string(&response).expect("must serialize to JSON");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("output is valid JSON");
+        let states = parsed["contract_states"]
+            .as_object()
+            .expect("contract_states must be a JSON object");
+        assert_eq!(states.len(), 1);
+        assert_eq!(
+            states["6kVs66bKaQAC6ohr8b43SvJ95r36tc2hnG7HezmaJHF9"]["subscribers"],
+            3
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

`NodeDiagnosticsResponse.contract_states` was `HashMap<ContractKey, ContractState>`. `ContractKey` derives `Serialize` as a struct (`{instance, code}`), but `serde_json` rejects non-string JSON object keys with `key must be a string`. The wire path between freenet-core and clients uses bincode, which does not care about key types, so the bug was invisible until the `freenet service report` binary tried to serialize the response to JSON for upload — every report from a node hosting at least one contract has been silently uploading an empty `network_status` since the field was added in June 2025.

The user-facing report bug was masked further by report.rs swallowing the WS query error until #3897/#3898 surfaced it. See freenet/freenet-core#3987 for the user-impact details and the full story.

## Solution

Switch the key type to `String` (Base58 contract id, matching the existing `ContractKey::Display` impl). This is the convention every other field in this struct already uses:
- `NodeInfo.peer_id: String`
- `NetworkInfo.connected_peers: Vec<(String, String)>`
- `ConnectedPeerInfo.peer_id: String`, `address: String`
- `ContractHostingEntry.contract_key: String`

`contract_states` was the lone outlier. The fix makes the type consistent with sibling diagnostic fields and unblocks the JSON serialization path at the source.

## Wire-format compatibility

This is a **bincode wire-format break** for `NodeDiagnosticsResponse`. Older clients built against 0.6.x that decode the `HostResponse::QueryResponse(QueryResponse::NodeDiagnostics(_))` variant will fail to deserialize the new payload.

Known consumers of `NodeDiagnosticsResponse`:
- `freenet-core/crates/fdev/src/diagnostics.rs` (the `fdev query`/`diagnostics` commands) — already calls `key.to_string()` on the map key, so it is forward-compatible source-wise. fdev is shipped with freenet-core releases and rebuilt in lockstep.
- `freenet-core/crates/core/src/bin/commands/report.rs` (the `freenet service report` binary) — was already broken on the old shape; freenet/freenet-core#3989 lands a local workaround so the report fix doesn't depend on this stdlib release.
- `freenet-core/crates/core/src/node/network_bridge/p2p_protoc.rs` (the producer side, inserts into the map) — will need to call `.to_string()` on the contract key when freenet-core bumps to a stdlib that includes this change.

No external consumers are known. Riverctl and River UI do not call `NodeDiagnostics`.

## Testing

Adds `node_diagnostics_response_tests::node_diagnostics_response_json_round_trips` in `client_events.rs`, which constructs a populated `NodeDiagnosticsResponse` and asserts:
- `serde_json::to_string(&response)` succeeds (the case the bug broke)
- The output round-trips back to JSON
- The Base58 key is preserved verbatim

Why this regression test wasn't there before: there was no JSON round-trip test for `NodeDiagnosticsResponse` in either repo. The wire path used in production is bincode, which does not exercise the JSON-key-must-be-string constraint. This test closes that gap at the source — any future field whose key type does not serialize as a string would break this test.

`cargo test --workspace` clean (19 stdlib tests + 1 new). `cargo fmt --check` clean. `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Release notes

Updated `CHANGELOG.md` under `[Unreleased]`. This change is queued for the next stdlib release; it does not need to land before freenet/freenet-core#3989, which fixes the user-facing report bug independently.

## Refs

- freenet/freenet-core#3987 — user-facing bug report
- freenet/freenet-core#3989 — companion freenet-core fix that does not require this stdlib change to land

[AI-assisted - Claude]