### PR TITLE
chore: bump freenet-git mirror-repo.yml pin a931790 -> 8f00293

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -37,7 +37,7 @@ jobs:
     # under this caller's secrets. Acceptable today because we control
     # crates.io publishing for that crate; if that changes, override
     # `freenet_git_version` here with a pinned semver.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@a93179077a4175ac4de324fc37fe57a3679f6bc8
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@8f00293929f39aaee9f0ea7ab334c15856def8f6
     with:
       freenet_repo: "96rknpy1GYhZ/freenet-stdlib"
       mode: history


### PR DESCRIPTION
## Summary

Bumps the SHA pin for the reusable mirror workflow from `a9317907` to `8f002939` (latest on freenet-git/main after v0.1.20).

## Picks up

- **0.1.18** — `--only-current-tips` filter for snapshot-mode rescue (no effect for this caller — stdlib uses history mode).
- **0.1.19** — parallel rescue + auto-detect `mirror-mode` contract extension. `mirror-repo.yml` now sets `FREENET_GIT_MIRROR_MODE: \${{ inputs.mode }}` on the push step, so this caller's `mode: history` records `mirror-mode=history` on the contract starting with the next push (which rescue auto-detects).
- **0.1.20** — `refs/tags/*` push in history mode (freenet-git#40). After this bump, the next mirror run will push every tag in `refs/tags/*` to `freenet:96rknpy1GYhZ/freenet-stdlib`, so fresh clones see release tags via `git ls-remote`.
- Operational fixes: matrix routing (#39), rescue timeout (#41), self-mirror force-push (#38).

## Test plan

- [ ] Merge → next push to main triggers the mirror via the new pin.
- [ ] Mirror run succeeds, installs freenet-git 0.1.20 from crates.io.
- [ ] `mirror-mode=history` extension lands on contract `96rknpy1GYhZ/freenet-stdlib`.
- [ ] Tag refs land in the contract: `git ls-remote freenet::96rknpy1GYhZ/freenet-stdlib` lists `refs/tags/v0.1.x` etc.

[AI-assisted - Claude]