### PR TITLE
feat!: remove DEFAULT_CIPHER/DEFAULT_NONCE public constants

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -581,16 +581,6 @@ pub enum DelegateRequest<'a> {
 }
 
 impl DelegateRequest<'_> {
-    pub const DEFAULT_CIPHER: [u8; 32] = [
-        0, 24, 22, 150, 112, 207, 24, 65, 182, 161, 169, 227, 66, 182, 237, 215, 206, 164, 58, 161,
-        64, 108, 157, 195, 0, 0, 0, 0, 0, 0, 0, 0,
-    ];
-
-    pub const DEFAULT_NONCE: [u8; 24] = [
-        57, 18, 79, 116, 63, 134, 93, 39, 208, 161, 156, 229, 222, 247, 111, 79, 210, 126, 127, 55,
-        224, 150, 139, 80,
-    ];
-
     pub fn into_owned(self) -> DelegateRequest<'static> {
         match self {
             DelegateRequest::ApplicationMessages {


### PR DESCRIPTION
## Problem

`DelegateRequest::DEFAULT_CIPHER` (`[u8; 32]`) and `DelegateRequest::DEFAULT_NONCE` (`[u8; 24]`) seeded a world-known XChaCha20-Poly1305 key and a fixed 24-byte nonce. Any freenet node that started without explicit `--cipher` / `--nonce` configuration encrypted all delegate secrets under this pair. Combined with the per-delegate nonce reuse fixed in [freenet-core PR #4143](https://github.com/freenet/freenet-core/pull/4143), the result was that default-configured nodes' delegate secrets were trivially recoverable by anyone who could read the secrets directory.

PR #4143 closed the catastrophic-reuse half (per-write random nonce + on-disk versioned format with legacy fallback). This stdlib PR closes the world-known-key half so the next freenet-core PR can replace the `DEFAULT_CIPHER` fallback with auto-generated, per-node persisted ciphers.

## Solution

Delete the two `pub const` declarations from `DelegateRequest`. The wire format `RegisterDelegate { cipher: [u8; 32], nonce: [u8; 24] }` is unchanged — only the named public constants are removed. Servers running freenet-core >= 0.2.59 generate per-write random nonces and treat the registration nonce as a read-side legacy fallback only.

Callers that previously named the consts must now:
- Generate a fresh 32-byte cipher per delegate (e.g. `XChaCha20Poly1305::generate_key(&mut OsRng)`).
- Pass any 24-byte nonce value for the wire field (commonly `[0u8; 24]`); it is no longer used by the server for new writes.

## Version bump

`0.7.0` → `0.8.0`. Pre-1.0 semver: removing public consts is a breaking change for any consumer that named them, so the minor version bumps.

## Wire-format pin tests

Untouched. The enum variant discriminants for `DelegateRequest` are not reordered, and the field shape of `RegisterDelegate` is unchanged. `*_wire_format_is_stable` tests continue to pass without modification.

## Testing

`cargo test --all` — 19 passed, 0 failed; doc-tests pass.
`cargo fmt --all --check` clean.
`cargo clippy --all -- -D warnings` clean.

## Next

After merge + `cargo publish 0.8.0` to crates.io, [freenet-core PR B2](https://github.com/freenet/freenet-core/issues/4139) will:
- Bump `freenet-stdlib = "0.8.0"`.
- Replace the `DEFAULT_CIPHER` fallback in `crates/core/src/config/secret.rs::SecretArgs::build` with an auto-generated cipher persisted to `secrets_dir/delegate_cipher` (mirroring the existing `transport_keypair` auto-persist).
- Drop the `--nonce` CLI flag (nonces are now per-write).
- Update test/fdev call sites that named the removed consts.

Refs: freenet/freenet-core#4137 (tracker), freenet/freenet-core#4139 (sub-issue).