### PR TITLE
chore(mirror): bump reusable-workflow pin and switch to MATRIX_DEV_ROOM_ID

### DIFF
--- a/.github/workflows/mirror-to-freenet.yml
+++ b/.github/workflows/mirror-to-freenet.yml
@@ -37,7 +37,7 @@ jobs:
     # under this caller's secrets. Acceptable today because we control
     # crates.io publishing for that crate; if that changes, override
     # `freenet_git_version` here with a pinned semver.
-    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@a93179077a4175ac4de324fc37fe57a3679f6bc8
+    uses: freenet/freenet-git/.github/workflows/mirror-repo.yml@8f00293929f39aaee9f0ea7ab334c15856def8f6
     with:
       freenet_repo: "96rknpy1GYhZ/freenet-stdlib"
       mode: history
@@ -45,7 +45,7 @@ jobs:
       FREENET_GIT_IDENTITY_BUNDLE_BASE64: ${{ secrets.FREENET_GIT_IDENTITY_BUNDLE_BASE64 }}
       FREENET_GIT_WS_URL: ${{ secrets.FREENET_GIT_WS_URL }}
       # Optional in the reusable workflow; passed through here so a
-      # mirror failure pings the team Matrix room instead of going
-      # silent. Both are org-level secrets at freenet.
+      # mirror failure pings the dev Matrix room (#freenet-dev) instead
+      # of going silent. Both are org-level secrets at freenet.
       MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-      MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
+      MATRIX_DEV_ROOM_ID: ${{ secrets.MATRIX_DEV_ROOM_ID }}


### PR DESCRIPTION
## Problem

This caller's mirror workflow is pinned to \`freenet-git@a93179\` (pre-#39) and passes \`MATRIX_ROOM_ID\` as the secret name. The reusable workflow at that pin still declared \`MATRIX_ROOM_ID\`, so it kept working, but:

1. **Stale workflow pin**: a93179 predates several improvements (#39 secret rename, #46 auto-detect snapshot/history rescue mode, #50 push refs/tags/* in history mode).
2. **Wrong secret name**: \`MATRIX_ROOM_ID\` is slated to be re-pointed at \`#freenet-locutus\` (community channel) once all dev-facing callers move to \`MATRIX_DEV_ROOM_ID\`. Without renaming this caller first, the org-secret flip would silently re-route mirror failure alerts from the dev channel into the community channel.

## Solution

Bump pin from \`a93179\` → \`8f00293\` (the merge SHA freenet-core's mirror workflow uses, for cross-repo consistency — the reusable workflow file content is identical between 8f00293 and current main as of 2026-05-16). Rename the secret pass-through from \`MATRIX_ROOM_ID\` → \`MATRIX_DEV_ROOM_ID\` to match the reusable workflow's declared input post-#39.

The reusable workflow's internal \`cargo install freenet-git --locked\` step still resolves to \`latest\`, so this caller picks up the freshly-published 0.1.22 (with the new fallback-failure error classification + Ian's #52 NotFound handling) on the next mirror run regardless of pin SHA. The pin only governs the YAML of the reusable workflow itself.

## Testing

YAML-only change. Validation is observational on the next scheduled cron (12:53 UTC daily) or first push to main after merge.

## Behavior

**Today**: no destination change. Both \`MATRIX_ROOM_ID\` and \`MATRIX_DEV_ROOM_ID\` happen to point at the same room (\`#freenet-dev\`'s room id), so failure alerts continue landing in \`#freenet-dev\`.

**After the org-secret flip**: \`MATRIX_ROOM_ID\` gets re-pointed at \`#freenet-locutus\` (matching its name). This PR is what makes that flip safe — without the rename, mirror failures would silently start announcing in the community channel.

## Companion changes

- freenet/freenet-core#4131 (merged): same rename in freenet-core's mirror caller.
- freenet/freenet-core#4133 (merged): gateway-side root cause fix for the rescue-demos 180s timeouts that triggered this whole investigation.
- freenet/freenet-git#52 + #54 (merged, published as 0.1.22): freenet-git diagnostic improvements (NotFound surfacing + dominant-outcome fallback error classification).

## Fixes

No GitHub issue filed — discovered while investigating recurring rescue-demos Matrix failure alerts for the freenet-stdlib mirror.

[AI-assisted - Claude]