### PR TITLE
fix: stop lowercasing CodeHash::encode Base58 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.8.0]
+
+### Fixed
+- `CodeHash::encode` no longer lowercases its Base58 output. The
+  BITCOIN alphabet is case-sensitive, so lowercasing corrupted the
+  bytes for any hash whose encoding contained uppercase characters and
+  broke the `encode` → `ContractKey::from_params` roundtrip (which
+  decodes with the same case-sensitive alphabet). `CodeHash::encode`
+  now matches `ContractInstanceId::encode`,
+  `ContractKey::encoded_code_hash`, and `ContractCode::hash_str`, all
+  of which already preserved case. See freenet/freenet-core#4214.
+
 ## [0.7.0]
 
 ### Fixed (wire-format break in `NodeDiagnosticsResponse`)

--- a/rust/src/code_hash.rs
+++ b/rust/src/code_hash.rs
@@ -32,7 +32,6 @@ impl CodeHash {
         bs58::encode(self.0)
             .with_alphabet(bs58::Alphabet::BITCOIN)
             .into_string()
-            .to_lowercase()
     }
 }
 
@@ -78,5 +77,30 @@ impl Display for CodeHash {
 impl std::fmt::Debug for CodeHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("CodeHash").field(&self.encode()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_roundtrips_with_case_sensitive_alphabet() {
+        // Bytes chosen so the base58 encoding contains uppercase characters,
+        // which a lowercasing `encode` would corrupt.
+        let original = CodeHash([0xFF; CONTRACT_KEY_SIZE]);
+        let encoded = original.encode();
+        assert!(
+            encoded.chars().any(|c| c.is_ascii_uppercase()),
+            "test fixture must contain uppercase base58 chars, got {encoded}"
+        );
+
+        let mut decoded = [0u8; CONTRACT_KEY_SIZE];
+        bs58::decode(&encoded)
+            .with_alphabet(bs58::Alphabet::BITCOIN)
+            .onto(&mut decoded)
+            .expect("encoded CodeHash must decode with the BITCOIN alphabet");
+
+        assert_eq!(original.0, decoded);
     }
 }


### PR DESCRIPTION
The BITCOIN Base58 alphabet is case-sensitive, so lowercasing the
encoded output corrupted any hash containing uppercase characters and
broke the encode -> ContractKey::from_params roundtrip, which decodes
with the same case-sensitive alphabet. This aligns CodeHash::encode
with ContractInstanceId::encode, ContractKey::encoded_code_hash, and
ContractCode::hash_str, which already preserve case.

Fixes freenet/freenet-core#4214

https://claude.ai/code/session_01ViYSqfF3NwQBiaVkzkWET6