### PR TITLE
fix: stop leaking every inbound WebSocket message in the WASM WebApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.8.3] - 2026-07-10
+
+### Fixed
+- **WASM `WebApi` leaked every inbound WebSocket message for the life of
+  the tab.** `WebApi::start`'s `onmessage` handler decoded each incoming
+  Blob with a per-message `FileReader` whose `onloadend` closure was
+  `forget()`-leaked; the leaked closure pinned the `FileReader`, and
+  `FileReader.result` pinned the full decoded payload, so every inbound
+  message's bytes were retained forever. Long-lived consumers (River)
+  grew to multi-GB tab memory in both Chrome and Firefox. The socket now
+  sets `binaryType = "arraybuffer"` and decodes `e.data()` synchronously
+  in `onmessage`, removing the Blob → `FileReader` async hop entirely, so
+  there is no per-message closure to leak and no `FileReader` to pin
+  payloads. Same wire format, same `HostResult` dispatch, same streaming
+  reassembly path — only the frame-decode transport changed. A non-binary
+  frame now reports a connection error through the normal error handler
+  instead of crashing on an unchecked cast. See
+  freenet/freenet-core#4746.
+- **`BorrowMutError` → WASM abort on any malformed or duplicate stream
+  chunk.** The `receive_chunk` `borrow_mut()` in the reassembly `match`
+  scrutinee lived until the end of the `match`, so the error arm's
+  `remove_stream` re-borrow panicked (`BorrowMutError`, aborting the WASM
+  instance) on any malformed or duplicate stream chunk. The borrow is now
+  hoisted out of the scrutinee. `binaryType` is also set before the
+  handlers are installed so the ordering is self-evidently safe rather
+  than relying on `start()` being synchronous. Pre-existing on `main`,
+  surfaced by PR review.
+
 ## [0.8.0]
 
 ### Fixed

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/rust/src/client_api/browser.rs
+++ b/rust/src/client_api/browser.rs
@@ -36,93 +36,81 @@ impl WebApi {
         let reassembly = Rc::new(RefCell::new(super::streaming::ReassemblyBuffer::new()));
 
         let onmessage_callback = Closure::<dyn FnMut(_)>::new(move |e: MessageEvent| {
-            // Extract the Blob from the MessageEvent
+            // Binary frames arrive as ArrayBuffer (`binaryType` is set below and
+            // must stay in sync with this decode path). Do NOT route through
+            // Blob + FileReader here: a per-message FileReader whose `onloadend`
+            // closure is `forget()`-leaked pins `FileReader.result`, retaining
+            // every inbound payload for the life of the tab
+            // (https://github.com/freenet/freenet-core/issues/4746).
             let value: JsValue = e.data();
-            let blob: web_sys::Blob = value.into();
+            let array_buffer = match value.dyn_into::<js_sys::ArrayBuffer>() {
+                Ok(ab) => ab,
+                Err(other) => {
+                    eh.borrow_mut()(Error::ConnectionError(serde_json::json!({
+                        "error": format!("unexpected non-binary websocket message: {other:?}"),
+                        "source": "host response decoding"
+                    })));
+                    return;
+                }
+            };
+            let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
 
-            // Create a FileReader to read the Blob
-            let file_reader = web_sys::FileReader::new().unwrap();
+            use super::client_events::HostResponse;
 
-            // Clone FileReader and function references for use in the onloadend_callback
-            let fr_clone = file_reader.clone();
-            let eh_clone = eh.clone();
-            let result_handler_clone = result_handler.clone();
-            let reassembly_clone = reassembly.clone();
+            let response: HostResult = match bincode::deserialize(&bytes) {
+                Ok(val) => val,
+                Err(err) => {
+                    eh.borrow_mut()(Error::ConnectionError(serde_json::json!({
+                        "error": format!("{err}"),
+                        "source": "host response deserialization"
+                    })));
+                    return;
+                }
+            };
 
-            let onloadend_callback = Closure::<dyn FnMut()>::new(move || {
-                let array_buffer = fr_clone
-                    .result()
-                    .unwrap()
-                    .dyn_into::<js_sys::ArrayBuffer>()
-                    .unwrap();
-                let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
-
-                use super::client_events::HostResponse;
-
-                let response: HostResult = match bincode::deserialize(&bytes) {
-                    Ok(val) => val,
-                    Err(err) => {
-                        eh_clone.borrow_mut()(Error::ConnectionError(serde_json::json!({
-                            "error": format!("{err}"),
-                            "source": "host response deserialization"
-                        })));
-                        return;
-                    }
-                };
-
-                match response {
-                    Ok(HostResponse::StreamHeader { .. }) => {
-                        // StreamHeader is metadata only — the following StreamChunks
-                        // will be reassembled transparently by the ReassemblyBuffer.
-                        // Browser incremental streaming is not yet supported.
-                        return;
-                    }
-                    Ok(HostResponse::StreamChunk {
-                        stream_id,
-                        index,
-                        total,
-                        data,
-                    }) => {
-                        match reassembly_clone
-                            .borrow_mut()
-                            .receive_chunk(stream_id, index, total, data)
-                        {
-                            Ok(Some(complete)) => {
-                                let inner: HostResult = match bincode::deserialize(&complete) {
-                                    Ok(val) => val,
-                                    Err(err) => {
-                                        eh_clone.borrow_mut()(Error::ConnectionError(
-                                            serde_json::json!({
-                                                "error": format!("{err}"),
-                                                "source": "stream reassembly deserialization"
-                                            }),
-                                        ));
-                                        return;
-                                    }
-                                };
-                                result_handler_clone.borrow_mut()(inner);
-                            }
-                            Ok(None) => return, // more chunks needed
-                            Err(e) => {
-                                reassembly_clone.borrow_mut().remove_stream(stream_id);
-                                eh_clone.borrow_mut()(Error::ConnectionError(serde_json::json!({
-                                    "error": format!("{e}"),
-                                    "source": "streaming reassembly"
-                                })));
-                                return;
-                            }
+            match response {
+                Ok(HostResponse::StreamHeader { .. }) => {
+                    // StreamHeader is metadata only — the following StreamChunks
+                    // will be reassembled transparently by the ReassemblyBuffer.
+                    // Browser incremental streaming is not yet supported.
+                }
+                Ok(HostResponse::StreamChunk {
+                    stream_id,
+                    index,
+                    total,
+                    data,
+                }) => {
+                    match reassembly
+                        .borrow_mut()
+                        .receive_chunk(stream_id, index, total, data)
+                    {
+                        Ok(Some(complete)) => {
+                            let inner: HostResult = match bincode::deserialize(&complete) {
+                                Ok(val) => val,
+                                Err(err) => {
+                                    eh.borrow_mut()(Error::ConnectionError(serde_json::json!({
+                                        "error": format!("{err}"),
+                                        "source": "stream reassembly deserialization"
+                                    })));
+                                    return;
+                                }
+                            };
+                            result_handler.borrow_mut()(inner);
+                        }
+                        Ok(None) => (), // more chunks needed
+                        Err(e) => {
+                            reassembly.borrow_mut().remove_stream(stream_id);
+                            eh.borrow_mut()(Error::ConnectionError(serde_json::json!({
+                                "error": format!("{e}"),
+                                "source": "streaming reassembly"
+                            })));
                         }
                     }
-                    other => {
-                        result_handler_clone.borrow_mut()(other);
-                    }
                 }
-            });
-
-            // Set the FileReader handlers
-            file_reader.set_onloadend(Some(onloadend_callback.as_ref().unchecked_ref()));
-            file_reader.read_as_array_buffer(&blob).unwrap();
-            onloadend_callback.forget();
+                other => {
+                    result_handler.borrow_mut()(other);
+                }
+            }
         });
         conn.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
         onmessage_callback.forget();
@@ -161,7 +149,9 @@ impl WebApi {
         conn.set_onclose(Some(onclose_callback.as_ref().unchecked_ref()));
         onclose_callback.forget();
 
-        conn.set_binary_type(web_sys::BinaryType::Blob);
+        // Deliver binary frames as ArrayBuffer so `onmessage` can decode them
+        // synchronously, with no per-message FileReader (see comment there).
+        conn.set_binary_type(web_sys::BinaryType::Arraybuffer);
         WebApi {
             conn,
             error_handler: Box::new(error_handler),

--- a/rust/src/client_api/browser.rs
+++ b/rust/src/client_api/browser.rs
@@ -31,13 +31,19 @@ impl WebApi {
     where
         ErrFn: FnMut(Error) + Clone + 'static,
     {
+        // Deliver binary frames as ArrayBuffer so `onmessage` can decode them
+        // synchronously, with no per-message FileReader (see comment there).
+        // Set before the handlers are installed so no dispatched frame can
+        // observe the default Blob type.
+        conn.set_binary_type(web_sys::BinaryType::Arraybuffer);
+
         let eh = Rc::new(RefCell::new(error_handler.clone()));
         let result_handler = Rc::new(RefCell::new(result_handler));
         let reassembly = Rc::new(RefCell::new(super::streaming::ReassemblyBuffer::new()));
 
         let onmessage_callback = Closure::<dyn FnMut(_)>::new(move |e: MessageEvent| {
-            // Binary frames arrive as ArrayBuffer (`binaryType` is set below and
-            // must stay in sync with this decode path). Do NOT route through
+            // Binary frames arrive as ArrayBuffer (`binaryType` is set in
+            // `start()` and must stay in sync with this decode path). Do NOT route through
             // Blob + FileReader here: a per-message FileReader whose `onloadend`
             // closure is `forget()`-leaked pins `FileReader.result`, retaining
             // every inbound payload for the life of the tab
@@ -80,10 +86,13 @@ impl WebApi {
                     total,
                     data,
                 }) => {
-                    match reassembly
+                    // Bind the outcome before matching: a `borrow_mut()` in the
+                    // match scrutinee lives until the end of the match, so
+                    // re-borrowing `reassembly` inside an arm would panic.
+                    let outcome = reassembly
                         .borrow_mut()
-                        .receive_chunk(stream_id, index, total, data)
-                    {
+                        .receive_chunk(stream_id, index, total, data);
+                    match outcome {
                         Ok(Some(complete)) => {
                             let inner: HostResult = match bincode::deserialize(&complete) {
                                 Ok(val) => val,
@@ -149,9 +158,6 @@ impl WebApi {
         conn.set_onclose(Some(onclose_callback.as_ref().unchecked_ref()));
         onclose_callback.forget();
 
-        // Deliver binary frames as ArrayBuffer so `onmessage` can decode them
-        // synchronously, with no per-message FileReader (see comment there).
-        conn.set_binary_type(web_sys::BinaryType::Arraybuffer);
         WebApi {
             conn,
             error_handler: Box::new(error_handler),

--- a/rust/src/contract_interface/encoding.rs
+++ b/rust/src/contract_interface/encoding.rs
@@ -84,10 +84,8 @@ impl RelatedContractsContainer {
     ) -> Result<Related<C>, <<C as EncodingAdapter>::SelfEncoder as Encoder<C>>::Error> {
         let id = <C as TypedContract>::instance_id(params);
         if let Some(res) = self.contracts.get(&id) {
-            match <<C as EncodingAdapter>::SelfEncoder>::deserialize(res.as_ref()) {
-                Ok(state) => return Ok(Related::Found { state }),
-                Err(err) => return Err(err),
-            }
+            let state = <<C as EncodingAdapter>::SelfEncoder>::deserialize(res.as_ref())?;
+            return Ok(Related::Found { state });
         }
         if self.pending.contains(&id) {
             return Ok(Related::RequestPending);


### PR DESCRIPTION
Fixes freenet/freenet-core#4746 (issues are disabled on this repo).

## Problem

`WebApi::start`'s `onmessage` handler read every incoming Blob with a per-message `FileReader` whose `onloadend` closure was `forget()`-leaked. The leaked closure pins the FileReader, and `FileReader.result` pins the full decoded payload, so **every inbound WebSocket message's bytes were retained for the life of the tab**. Long-lived consumers (River) grow to multi-GB tab memory in both Chrome and Firefox.

Measured live against a real node (headless Chrome 149 driven over CDP, 3-room signed-in River tab): 506 leaked FileReaders retaining 65 MB of ArrayBuffers after ~80 mostly-idle minutes; +15 per tab-switch-back (River refreshes all rooms on `visibilitychange`), +12 per reconnect; FileReader count tracks the `JSEventListeners` metric 1:1. Details and full methodology in freenet/freenet-core#4746.

## Fix

Set `binaryType = "arraybuffer"` on the socket and decode `e.data()` synchronously in `onmessage`. This removes the Blob → FileReader async hop entirely, so there is no per-message closure to leak and no FileReader to pin payloads. A non-binary frame (which the old code would have crashed on via unchecked casts) now reports a connection error through the normal error handler.

Behavioral notes:
- Same wire format, same `HostResult` dispatch, same streaming reassembly path — only the frame-decode transport changed.
- Decode now happens in the same microtask as message delivery instead of a FileReader callback; ordering between messages is unchanged (FileReader completions were already FIFO in practice, but ArrayBuffer delivery removes any reliance on that).
- The per-connection `forget()`s (onmessage/onerror/onopen/onclose, ~4 closures per reconnect) remain; they're bounded and small, noted in #4746 as a follow-up.

## Verification

- `cargo check`/`clippy --target wasm32-unknown-unknown --features net` clean; native tests pass; fmt clean.
- The retention mechanism was pinpointed empirically (queryObjects census: FileReaders were the only growing object class, all `readyState DONE`, holding exactly the leaked bytes); this change removes that object class from the path by construction.

[AI-assisted - Claude]
