### PR TITLE
fix: gate flatbuffers regeneration behind REGEN_FLATBUFFERS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ We welcome contributions to Freenet! Here's what you need to know.
 - Bug fixes should include a regression test that fails without the fix.
 - Run `cargo fmt`, `cargo clippy --all-targets`, and `cargo test` before pushing.
 - Keep PRs focused — one logical change per PR.
+- The flatbuffers bindings in `rust/src/generated/` are checked in and are the source of truth. A normal build does **not** regenerate them. If you edit a schema under `schemas/flatbuffers/`, regenerate with `REGEN_FLATBUFFERS=1 cargo build` and commit the `.fbs` and its regenerated `_generated.rs` together.
 
 ## AI-Assisted Contributions
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,6 +1,21 @@
 use std::process::Command;
 
 fn main() {
+    // The checked-in files in src/generated are the source of truth; regenerating
+    // them on every build with the local flatc dirtied the tree (freenet-core#4747).
+    // After editing a schema, regenerate with `REGEN_FLATBUFFERS=1 cargo build`.
+    println!("cargo:rerun-if-env-changed=REGEN_FLATBUFFERS");
+    let regen = std::env::var("REGEN_FLATBUFFERS").unwrap_or_default();
+    if regen.is_empty() || regen == "0" {
+        return;
+    }
+
+    println!("cargo:rerun-if-changed=../schemas/flatbuffers/common.fbs");
+    println!("cargo:rerun-if-changed=../schemas/flatbuffers/client_request.fbs");
+    println!("cargo:rerun-if-changed=../schemas/flatbuffers/host_response.fbs");
+
+    // Regeneration was requested explicitly, so fail loudly rather than
+    // succeed with stale files.
     let status = Command::new("flatc")
         .arg("--rust")
         .arg("-o")
@@ -8,11 +23,13 @@ fn main() {
         .arg("../schemas/flatbuffers/common.fbs")
         .arg("../schemas/flatbuffers/client_request.fbs")
         .arg("../schemas/flatbuffers/host_response.fbs")
-        .status();
-    if let Err(err) = status {
-        println!("failed compiling flatbuffers schema: {err}");
-        println!("refer to https://github.com/google/flatbuffers to install the flatc compiler");
-    } else {
-        let _ = Command::new("cargo").arg("fmt").status();
-    }
+        .status()
+        .unwrap_or_else(|err| {
+            panic!(
+                "REGEN_FLATBUFFERS is set but flatc could not be run: {err}\n\
+                 refer to https://github.com/google/flatbuffers to install the flatc compiler"
+            )
+        });
+    assert!(status.success(), "flatc failed with {status}");
+    let _ = Command::new("cargo").arg("fmt").status();
 }


### PR DESCRIPTION
## Problem

`rust/build.rs` ran `flatc --rust -o src/generated ...` on every build, rewriting the checked-in generated files with whatever flatc is installed locally. A mismatched flatc turned a plain `cargo check` into ~4k dirty tracked lines, which twice got swept into commits (#72, reverted by #73; the initial commit of #83).

## Solution

Regeneration is now opt-in (option 2 from the issue):

- Normal builds never touch `src/generated/` and don't require flatc — the checked-in files are the source of truth.
- After editing a schema, run `REGEN_FLATBUFFERS=1 cargo build` and commit the `.fbs` and regenerated `.rs` together (documented in CONTRIBUTING.md). `REGEN_FLATBUFFERS=0` or empty counts as unset.
- Since regeneration is now explicit, it fails loudly: missing flatc or a nonzero flatc exit panics the build script instead of silently succeeding with stale files.

## Testing

| Scenario | Result |
|----------|--------|
| `cargo check` (no env var) | `src/generated/` untouched, flatc not required |
| `REGEN_FLATBUFFERS=0 cargo build` | no regeneration |
| `REGEN_FLATBUFFERS=1 cargo build` | regenerates, output matches checked-in files |
| `REGEN_FLATBUFFERS=1` without flatc | build fails with a clear message |

Possible follow-up: a CI job regenerating with a pinned flatc that fails on diff.

## Fixes

Closes freenet/freenet-core#4747