### PR TITLE
fix: pass ContractKey code hash through FBS decode instead of re-hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`ContractKey::try_decode_fbs` no longer double-hashes the code hash.** The
+  wire `code` field carries the already-computed 32-byte code hash, but the
+  decoder passed it to `CodeHash::from_code` — the *hashing* constructor —
+  producing `BLAKE3(BLAKE3(wasm))`, a key that never matches the store. Every
+  FlatBuffers `UpdateRequest` failed as a result, which the client surfaced as
+  a 30-second timeout rather than an error. GET and SUBSCRIBE were unaffected
+  because their request variants carry only an instance id and never decode
+  `code`. The regression dates to `844880e` (Nov 2023), which changed a
+  pass-through `CodeHash::new` into `from_code`. Blast radius was FlatBuffers
+  clients, the TypeScript SDK's default, so browser apps: the audience least
+  able to diagnose it.
+
+- **A wrong-length `instance` no longer panics the connection task.**
+  `instance`/`data` are `(required)` in the schema, but the flatbuffers
+  verifier checks that a required vector is present, not that it is the right
+  length. An 8-byte instance passed verification and then hit a
+  `try_into().unwrap()`, panicking with `TryFromSliceError`; nothing catches
+  unwind on that path, so a malformed message from any peer killed that
+  client's connection task. Reachable from UPDATE, GET and SUBSCRIBE; all
+  three now reject with an explicit error.
+
+### Compatibility
+- **A `ContractKey` whose `code` field is absent or not exactly 32 bytes is now
+  rejected at decode.** This is a hard rejection of a shape `common.fbs`
+  permits (`code` is not `(required)`) and that the TypeScript SDK actually
+  emits: `ContractKey.fromInstanceId(...)` produces a present-but-zero-length
+  vector, and the SDK's own test suite builds an `UpdateRequest` that way.
+
+  **No working client regresses.** Such an UPDATE has never succeeded. The node
+  gates an UPDATE on already holding the contract's code blob and probes for it
+  by code hash; an UPDATE supplies no contract code, so a zero-length `code`
+  hashed to `BLAKE3("")` and failed at that gate. What changes is *where* and
+  *how* it fails: previously a 30-second timeout or an opaque
+  `"missing contract: <key>"` pointing at the node, now an immediate
+  `ContractKey.code must be the 32-byte contract code hash; got 0 bytes...`
+  naming the field and the remedy.
+
+  The real fix is for the node to resolve the code hash from the instance id,
+  as GET and SUBSCRIBE already do via `code_hash_from_id` — tracked in
+  freenet-core#4978. Until then, build keys with both parts:
+  `new ContractKey(instance, code)` rather than
+  `ContractKey.fromInstanceId(...)`.
+
 ## [0.8.4] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   unchecked-`unwrap` class survives elsewhere on the same UPDATE request -
   `UpdateData`'s `Related*` variants apply base58 decoding to bytes already in
   final form and then unwrap: so an FBS UPDATE carrying one of those variants
-  still panics. Tracked in freenet-core#4983.
+  still panics. Tracked in freenet-core#4996.
 
 ### Compatibility
 - **A `ContractKey` whose `code` field is absent or not exactly 32 bytes is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - **`ContractKey::try_decode_fbs` no longer double-hashes the code hash.** The
   wire `code` field carries the already-computed 32-byte code hash, but the
-  decoder passed it to `CodeHash::from_code` — the *hashing* constructor —
+  decoder passed it to `CodeHash::from_code`: the *hashing* constructor -
   producing `BLAKE3(BLAKE3(wasm))`, a key that never matches the store. Every
   FlatBuffers `UpdateRequest` failed as a result, which the client surfaced as
   a 30-second timeout rather than an error. GET and SUBSCRIBE were unaffected
@@ -21,8 +21,14 @@
   length. An 8-byte instance passed verification and then hit a
   `try_into().unwrap()`, panicking with `TryFromSliceError`; nothing catches
   unwind on that path, so a malformed message from any peer killed that
-  client's connection task. Reachable from UPDATE, GET and SUBSCRIBE; all
-  three now reject with an explicit error.
+  client's connection task. The `ContractKey.instance` field is now
+  length-checked at all three sites that decode it (UPDATE, GET, SUBSCRIBE).
+
+  Note the narrow scope: this covers the `ContractKey` fields only. The same
+  unchecked-`unwrap` class survives elsewhere on the same UPDATE request -
+  `UpdateData`'s `Related*` variants apply base58 decoding to bytes already in
+  final form and then unwrap: so an FBS UPDATE carrying one of those variants
+  still panics. Tracked in freenet-core#4983.
 
 ### Compatibility
 - **A `ContractKey` whose `code` field is absent or not exactly 32 bytes is now
@@ -41,7 +47,7 @@
   naming the field and the remedy.
 
   The real fix is for the node to resolve the code hash from the instance id,
-  as GET and SUBSCRIBE already do via `code_hash_from_id` — tracked in
+  as GET and SUBSCRIBE already do via `code_hash_from_id`: tracked in
   freenet-core#4978. Until then, build keys with both parts:
   `new ContractKey(instance, code)` rather than
   `ContractKey.fromInstanceId(...)`.

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -503,8 +503,9 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                     // Extract just the instance ID - GET only needs the instance ID,
                     // not the full key (which may not be complete on the client side)
                     let fbs_key = get.key();
-                    let key_bytes: [u8; 32] = fbs_key.instance().data().bytes().try_into().unwrap();
-                    let key = ContractInstanceId::new(key_bytes);
+                    let key = crate::contract_interface::key::instance_id_from_fbs(
+                        fbs_key.instance().data().bytes(),
+                    )?;
                     let fetch_contract = get.fetch_contract();
                     let subscribe = get.subscribe();
                     let blocking_subscribe = get.blocking_subscribe();
@@ -541,8 +542,9 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                     let subscribe = request.contract_request_as_subscribe().unwrap();
                     // Extract just the instance ID for Subscribe
                     let fbs_key = subscribe.key();
-                    let key_bytes: [u8; 32] = fbs_key.instance().data().bytes().try_into().unwrap();
-                    let key = ContractInstanceId::new(key_bytes);
+                    let key = crate::contract_interface::key::instance_id_from_fbs(
+                        fbs_key.instance().data().bytes(),
+                    )?;
                     let summary = subscribe
                         .summary()
                         .map(|summary_data| StateSummary::from(summary_data.bytes()));
@@ -2107,6 +2109,71 @@ mod client_request_test {
         }
 
         Ok(())
+    }
+
+    /// The exact bytes the TypeScript SDK's own test suite asserts as a correct
+    /// `UpdateRequest` — pinned here so the two suites cannot disagree silently.
+    ///
+    /// Copied verbatim from `typescript/tests/websocket-interface.test.ts`
+    /// (`EXPECTED_UPDATE_REQ`). It is byte-for-byte the blob this PR deleted
+    /// from the Rust side, which is exactly how the original double-hash bug
+    /// survived: both suites pinned the same bytes in mirror, and neither ever
+    /// crossed the language boundary, so a shape that no Rust decoder accepted
+    /// stayed "verified" on the TypeScript side.
+    ///
+    /// Its `code` field is present and ZERO-LENGTH, which is what
+    /// `ContractKey.fromInstanceId(...)` emits. After this change the Rust
+    /// decoder hard-errors on it, while `npm test` still asserts it is correct
+    /// and stays green. Both suites run in CI, so this test is the only thing
+    /// that makes that disagreement visible.
+    ///
+    /// **If the TypeScript SDK is fixed** (see freenet/freenet-core#4978 — the
+    /// candidate is making `UpdateRequest` reject a key whose `code` is not 32
+    /// bytes), this test and the TS suite's expected-byte array must be updated
+    /// together. Leaving one behind re-creates the mirror-pinning that hid the
+    /// original bug.
+    const TS_SDK_EXPECTED_UPDATE_REQ: &[u8] = &[
+        4, 0, 0, 0, 220, 255, 255, 255, 8, 0, 0, 0, 0, 0, 0, 1, 232, 255, 255, 255, 8, 0, 0, 0, 0,
+        0, 0, 2, 204, 255, 255, 255, 16, 0, 0, 0, 52, 0, 0, 0, 8, 0, 12, 0, 11, 0, 4, 0, 8, 0, 0,
+        0, 8, 0, 0, 0, 0, 0, 0, 2, 210, 255, 255, 255, 4, 0, 0, 0, 8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7,
+        8, 8, 0, 12, 0, 8, 0, 4, 0, 8, 0, 0, 0, 8, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 8,
+        0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 32, 0, 0, 0, 85, 111, 11, 171, 40, 85, 240, 177, 207, 81,
+        106, 157, 173, 90, 234, 2, 250, 253, 75, 210, 62, 7, 6, 34, 75, 26, 229, 230, 107, 167, 17,
+        108,
+    ];
+
+    /// The cross-language contract: what the TypeScript SDK emits for an
+    /// instance-id-only UPDATE is rejected here, with the actionable message.
+    ///
+    /// Asserting the MESSAGE and not just the rejection is the point. The
+    /// TypeScript developer whose request this is gets exactly this string
+    /// back over the WebSocket, and it is the only thing telling them the key
+    /// needs both parts. A revert to the bare `try_from` error would leave the
+    /// rejection green while restoring `"invalid data"`.
+    #[test]
+    fn typescript_sdk_instance_only_update_is_rejected_with_guidance() {
+        let client_request = root_as_client_request(TS_SDK_EXPECTED_UPDATE_REQ)
+            .expect("the TS SDK blob must still be a well-formed ClientRequest");
+        let contract_request = client_request
+            .client_request_as_contract_request()
+            .expect("the TS SDK blob must still be a ContractRequest");
+
+        let err = ContractRequest::try_decode_fbs(&contract_request)
+            .expect_err("an instance-id-only UPDATE must be rejected");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("ContractKey.code") && msg.contains("got 0 bytes"),
+            "the TS SDK's zero-length code must be named explicitly, got: {msg}"
+        );
+        assert!(
+            msg.contains("new ContractKey(instance, code)"),
+            "the error must tell a TypeScript developer how to build the key, got: {msg}"
+        );
+        assert!(
+            msg.contains("4978"),
+            "the error must point at the tracking issue for the real fix, got: {msg}"
+        );
     }
 
     /// The flatbuffers decode path must NOT panic on an unknown

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -1993,17 +1993,94 @@ mod client_request_test {
         Ok(())
     }
 
+    /// A well-formed FlatBuffers `UpdateRequest` decodes to the expected key
+    /// and delta.
+    ///
+    /// Built programmatically rather than from a hardcoded byte blob. The blob
+    /// this replaces carried a present-but-ZERO-LENGTH `code` field, which is
+    /// what the TypeScript SDK's `ContractKey.fromInstanceId(...)` emits — a
+    /// request the node cannot serve, because an UPDATE supplies no contract
+    /// code and freenet-core resolves the WASM by code hash. Nobody could see
+    /// that from reading the test; it took instrumenting the decoder. So the
+    /// fixture now carries a real 32-byte hash and says so in source.
+    ///
+    /// The empty and absent cases are covered in
+    /// `contract_interface::key::fbs_tests`, next to the decoder that rejects
+    /// them.
     #[test]
     fn test_build_contract_update_op_from_fbs() -> Result<(), Box<dyn std::error::Error>> {
-        let update_op = vec![
-            4, 0, 0, 0, 220, 255, 255, 255, 8, 0, 0, 0, 0, 0, 0, 1, 232, 255, 255, 255, 8, 0, 0, 0,
-            0, 0, 0, 2, 204, 255, 255, 255, 16, 0, 0, 0, 52, 0, 0, 0, 8, 0, 12, 0, 11, 0, 4, 0, 8,
-            0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 2, 210, 255, 255, 255, 4, 0, 0, 0, 8, 0, 0, 0, 1, 2, 3,
-            4, 5, 6, 7, 8, 8, 0, 12, 0, 8, 0, 4, 0, 8, 0, 0, 0, 8, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 32, 0, 0, 0, 85, 111, 11, 171, 40,
-            85, 240, 177, 207, 81, 106, 157, 173, 90, 234, 2, 250, 253, 75, 210, 62, 7, 6, 34, 75,
-            26, 229, 230, 107, 167, 17, 108,
-        ];
+        use crate::generated::client_request::{
+            finish_client_request_buffer, ClientRequest as FbsClientRequest, ClientRequestArgs,
+            ClientRequestType, ContractRequest as FbsContractRequest, ContractRequestArgs,
+            ContractRequestType, Update as FbsUpdate, UpdateArgs,
+        };
+        use crate::generated::common::{
+            ContractInstanceId as FbsContractInstanceId, ContractInstanceIdArgs,
+            ContractKey as FbsContractKey, ContractKeyArgs, DeltaUpdate, DeltaUpdateArgs,
+            UpdateData as FbsUpdateData, UpdateDataArgs, UpdateDataType,
+        };
+        use crate::prelude::ContractInstanceId;
+
+        // Derive the instance bytes from the expected id rather than pasting a
+        // magic array, so the assertion below can't drift from the fixture.
+        let instance_id = ContractInstanceId::try_from(EXPECTED_ENCODED_CONTRACT_ID.to_string())?;
+        // A distinct, arbitrary code hash: if the decoder ever re-hashes it
+        // (the BLAKE3(BLAKE3(wasm)) bug this PR fixes), the assertion fails.
+        let code_hash = [42u8; 32];
+        let delta_bytes = [1u8, 2, 3, 4, 5, 6, 7, 8];
+
+        let mut b = flatbuffers::FlatBufferBuilder::new();
+
+        let instance_data = b.create_vector(instance_id.as_bytes());
+        let instance_offset = FbsContractInstanceId::create(
+            &mut b,
+            &ContractInstanceIdArgs {
+                data: Some(instance_data),
+            },
+        );
+        let code = Some(b.create_vector(&code_hash));
+        let key_offset = FbsContractKey::create(
+            &mut b,
+            &ContractKeyArgs {
+                instance: Some(instance_offset),
+                code,
+            },
+        );
+
+        let delta = b.create_vector(&delta_bytes);
+        let delta_offset = DeltaUpdate::create(&mut b, &DeltaUpdateArgs { delta: Some(delta) });
+        let update_data_offset = FbsUpdateData::create(
+            &mut b,
+            &UpdateDataArgs {
+                update_data_type: UpdateDataType::DeltaUpdate,
+                update_data: Some(delta_offset.as_union_value()),
+            },
+        );
+
+        let update_offset = FbsUpdate::create(
+            &mut b,
+            &UpdateArgs {
+                key: Some(key_offset),
+                data: Some(update_data_offset),
+            },
+        );
+        let contract_offset = FbsContractRequest::create(
+            &mut b,
+            &ContractRequestArgs {
+                contract_request_type: ContractRequestType::Update,
+                contract_request: Some(update_offset.as_union_value()),
+            },
+        );
+        let client_offset = FbsClientRequest::create(
+            &mut b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType::ContractRequest,
+                client_request: Some(contract_offset.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(&mut b, client_offset);
+
+        let update_op = b.finished_data().to_vec();
         let request = if let Ok(client_request) = root_as_client_request(&update_op) {
             let contract_request = client_request.client_request_as_contract_request().unwrap();
             ContractRequest::try_decode_fbs(&contract_request)?
@@ -2013,13 +2090,15 @@ mod client_request_test {
 
         match request {
             ContractRequest::Update { key, data } => {
+                assert_eq!(key.encoded_contract_id(), EXPECTED_ENCODED_CONTRACT_ID);
                 assert_eq!(
-                    key.encoded_contract_id(),
-                    "6kVs66bKaQAC6ohr8b43SvJ95r36tc2hnG7HezmaJHF9"
+                    key.code_hash().as_ref(),
+                    &code_hash,
+                    "the code hash must survive decode unchanged, not be re-hashed"
                 );
                 match data {
                     UpdateData::Delta(delta) => {
-                        assert_eq!(delta.to_vec(), &[1, 2, 3, 4, 5, 6, 7, 8])
+                        assert_eq!(delta.to_vec(), &delta_bytes)
                     }
                     _ => panic!("wrong update data type"),
                 }

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -1911,7 +1911,7 @@ mod node_diagnostics_response_tests {
 
 #[cfg(test)]
 mod client_request_test {
-    use crate::client_api::{ContractRequest, TryFromFbs};
+    use crate::client_api::{ContractRequest, TryFromFbs, WsApiError};
     use crate::contract_interface::UpdateData;
     use crate::generated::client_request::root_as_client_request;
 
@@ -2000,7 +2000,7 @@ mod client_request_test {
     ///
     /// Built programmatically rather than from a hardcoded byte blob. The blob
     /// this replaces carried a present-but-ZERO-LENGTH `code` field, which is
-    /// what the TypeScript SDK's `ContractKey.fromInstanceId(...)` emits — a
+    /// what the TypeScript SDK's `ContractKey.fromInstanceId(...)` emits: a
     /// request the node cannot serve, because an UPDATE supplies no contract
     /// code and freenet-core resolves the WASM by code hash. Nobody could see
     /// that from reading the test; it took instrumenting the decoder. So the
@@ -2112,7 +2112,7 @@ mod client_request_test {
     }
 
     /// The exact bytes the TypeScript SDK's own test suite asserts as a correct
-    /// `UpdateRequest` — pinned here so the two suites cannot disagree silently.
+    /// `UpdateRequest`: pinned here so the two suites cannot disagree silently.
     ///
     /// Copied verbatim from `typescript/tests/websocket-interface.test.ts`
     /// (`EXPECTED_UPDATE_REQ`). It is byte-for-byte the blob this PR deleted
@@ -2127,11 +2127,16 @@ mod client_request_test {
     /// and stays green. Both suites run in CI, so this test is the only thing
     /// that makes that disagreement visible.
     ///
-    /// **If the TypeScript SDK is fixed** (see freenet/freenet-core#4978 — the
-    /// candidate is making `UpdateRequest` reject a key whose `code` is not 32
-    /// bytes), this test and the TS suite's expected-byte array must be updated
-    /// together. Leaving one behind re-creates the mirror-pinning that hid the
-    /// original bug.
+    /// Scope, so this is not over-trusted: it is a COPY of the TypeScript
+    /// array, not a reference to it. Nothing mechanically ties the two, so
+    /// editing the TypeScript side fails nothing here. (`include_str!` across
+    /// to `typescript/` is not the fix: `rust/` is the published package root
+    /// and the path would escape it.) So this is a convention, and the
+    /// convention is: if the TypeScript SDK is fixed (see
+    /// freenet/freenet-core#4978, whose candidate is making `UpdateRequest`
+    /// reject a key whose `code` is not 32 bytes), update the array and this
+    /// constant together. Leaving one behind re-creates the mirror-pinning
+    /// that hid the original bug.
     const TS_SDK_EXPECTED_UPDATE_REQ: &[u8] = &[
         4, 0, 0, 0, 220, 255, 255, 255, 8, 0, 0, 0, 0, 0, 0, 1, 232, 255, 255, 255, 8, 0, 0, 0, 0,
         0, 0, 2, 204, 255, 255, 255, 16, 0, 0, 0, 52, 0, 0, 0, 8, 0, 12, 0, 11, 0, 4, 0, 8, 0, 0,
@@ -2173,6 +2178,145 @@ mod client_request_test {
         assert!(
             msg.contains("4978"),
             "the error must point at the tracking issue for the real fix, got: {msg}"
+        );
+    }
+
+    /// Build a `ClientRequest` carrying a GET or SUBSCRIBE whose `ContractKey`
+    /// has an `instance` vector of the given length.
+    ///
+    /// The length is a parameter because the flatbuffers verifier checks that a
+    /// `(required)` vector is PRESENT, not that it is the right SIZE, so a
+    /// wrong-length instance is a shape a peer can actually put on the wire and
+    /// that `flatbuffers::root` will happily hand to the decoder.
+    fn client_request_with_instance_len(instance_len: usize, subscribe: bool) -> Vec<u8> {
+        use crate::generated::client_request::{
+            finish_client_request_buffer, ClientRequest as FbsClientRequest, ClientRequestArgs,
+            ClientRequestType, ContractRequest as FbsContractRequest, ContractRequestArgs,
+            ContractRequestType, Get as FbsGet, GetArgs, Subscribe as FbsSubscribe, SubscribeArgs,
+        };
+        use crate::generated::common::{
+            ContractInstanceId as FbsContractInstanceId, ContractInstanceIdArgs,
+            ContractKey as FbsContractKey, ContractKeyArgs,
+        };
+
+        let mut b = flatbuffers::FlatBufferBuilder::new();
+        let instance_data = b.create_vector(&vec![1u8; instance_len]);
+        let instance_offset = FbsContractInstanceId::create(
+            &mut b,
+            &ContractInstanceIdArgs {
+                data: Some(instance_data),
+            },
+        );
+        let code = Some(b.create_vector(&[42u8; 32]));
+        let key_offset = FbsContractKey::create(
+            &mut b,
+            &ContractKeyArgs {
+                instance: Some(instance_offset),
+                code,
+            },
+        );
+
+        let (request_type, request_offset) = if subscribe {
+            let sub = FbsSubscribe::create(
+                &mut b,
+                &SubscribeArgs {
+                    key: Some(key_offset),
+                    summary: None,
+                },
+            );
+            (ContractRequestType::Subscribe, sub.as_union_value())
+        } else {
+            let get = FbsGet::create(
+                &mut b,
+                &GetArgs {
+                    key: Some(key_offset),
+                    fetch_contract: false,
+                    subscribe: false,
+                    blocking_subscribe: false,
+                },
+            );
+            (ContractRequestType::Get, get.as_union_value())
+        };
+
+        let contract_offset = FbsContractRequest::create(
+            &mut b,
+            &ContractRequestArgs {
+                contract_request_type: request_type,
+                contract_request: Some(request_offset),
+            },
+        );
+        let client_offset = FbsClientRequest::create(
+            &mut b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType::ContractRequest,
+                client_request: Some(contract_offset.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(&mut b, client_offset);
+        b.finished_data().to_vec()
+    }
+
+    fn decode_client_request(bytes: &[u8]) -> Result<ContractRequest<'_>, WsApiError> {
+        let client_request =
+            root_as_client_request(bytes).expect("must be a well-formed ClientRequest");
+        let contract_request = client_request
+            .client_request_as_contract_request()
+            .expect("must be a ContractRequest");
+        ContractRequest::try_decode_fbs(&contract_request)
+    }
+
+    /// A GET whose instance is the wrong length is rejected, not panicked on.
+    ///
+    /// Pinned at the REQUEST level rather than through `ContractKey`'s decoder,
+    /// because GET does not go through `ContractKey::try_decode_fbs` at all: it
+    /// reads the instance bytes directly. A test that only covers the UPDATE
+    /// path leaves a revert of this site green, which is exactly the state this
+    /// suite was in before: the panic fix reached three call sites and only one
+    /// of them was pinned.
+    #[test]
+    fn get_with_wrong_length_instance_is_rejected_not_panicking() {
+        let bytes = client_request_with_instance_len(8, false);
+        let short = decode_client_request(&bytes)
+            .expect_err("a GET with an 8-byte instance must be rejected");
+        assert!(
+            short.to_string().contains("ContractKey.instance")
+                && short.to_string().contains("got 8 bytes"),
+            "got: {short}"
+        );
+
+        let bytes = client_request_with_instance_len(64, false);
+        let long = decode_client_request(&bytes)
+            .expect_err("a GET with a 64-byte instance must be rejected");
+        assert!(long.to_string().contains("got 64 bytes"), "got: {long}");
+    }
+
+    /// Same for SUBSCRIBE, which is a third independent decode site.
+    #[test]
+    fn subscribe_with_wrong_length_instance_is_rejected_not_panicking() {
+        let bytes = client_request_with_instance_len(8, true);
+        let short = decode_client_request(&bytes)
+            .expect_err("a SUBSCRIBE with an 8-byte instance must be rejected");
+        assert!(
+            short.to_string().contains("ContractKey.instance")
+                && short.to_string().contains("got 8 bytes"),
+            "got: {short}"
+        );
+
+        let bytes = client_request_with_instance_len(64, true);
+        let long = decode_client_request(&bytes)
+            .expect_err("a SUBSCRIBE with a 64-byte instance must be rejected");
+        assert!(long.to_string().contains("got 64 bytes"), "got: {long}");
+    }
+
+    /// A well-formed GET still decodes: the length guard must reject the wrong
+    /// size without breaking the right one.
+    #[test]
+    fn get_with_valid_instance_still_decodes() {
+        let bytes = client_request_with_instance_len(32, false);
+        let req = decode_client_request(&bytes).expect("a 32-byte instance must still decode");
+        assert!(
+            matches!(req, ContractRequest::Get { .. }),
+            "expected a Get, got {req:?}"
         );
     }
 

--- a/rust/src/contract_interface/key.rs
+++ b/rust/src/contract_interface/key.rs
@@ -233,9 +233,20 @@ impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
     fn try_decode_fbs(key: &FbsContractKey<'a>) -> Result<Self, WsApiError> {
         let key_bytes: [u8; CONTRACT_KEY_SIZE] = key.instance().data().bytes().try_into().unwrap();
         let instance = ContractInstanceId::new(key_bytes);
+        // The `code` field carries the already-computed 32-byte code hash
+        // (BLAKE3 of the wasm), so pass those bytes straight through. Calling
+        // `CodeHash::from_code` here would hash the hash again —
+        // BLAKE3(BLAKE3(wasm)) — yielding a key that never matches the store and
+        // breaking every FlatBuffers UpdateRequest ("Contract not in store and
+        // no code provided"). GET/SUBSCRIBE dodged this because they decode only
+        // the instance id; UPDATE decodes the full key. The delegate decoder
+        // already does the pass-through correctly (see
+        // `DelegateKey::try_decode_fbs`). Regression test below.
         let code = key
             .code()
-            .map(|code_hash| CodeHash::from_code(code_hash.bytes()))
+            .map(|code_hash| CodeHash::try_from(code_hash.bytes()))
+            .transpose()
+            .map_err(|e| WsApiError::deserialization(e.to_string()))?
             .ok_or_else(|| WsApiError::deserialization("ContractKey missing code hash".into()))?;
         Ok(ContractKey { instance, code })
     }
@@ -267,4 +278,54 @@ pub(super) fn internal_fmt_key(
         .with_alphabet(bs58::Alphabet::BITCOIN)
         .into_string();
     write!(f, "{}", &r[..8])
+}
+
+#[cfg(test)]
+mod fbs_tests {
+    use super::*;
+    use crate::common_generated::common::{
+        ContractInstanceId as FbsContractInstanceId, ContractInstanceIdArgs, ContractKeyArgs,
+    };
+
+    /// The wire `code` field carries the raw 32-byte code hash, and the decoder
+    /// must return those exact bytes. Regression for the double-hash bug where
+    /// `try_decode_fbs` re-hashed the hash (BLAKE3(BLAKE3(wasm))), producing a
+    /// key that never matched the store and failing every FlatBuffers
+    /// UpdateRequest with "Contract not in store and no code provided".
+    #[test]
+    fn contract_key_code_hash_passes_through_fbs_decode() {
+        let instance_bytes = [7u8; CONTRACT_KEY_SIZE];
+        // A distinct, arbitrary code hash. The decoder must reproduce it
+        // verbatim; if it re-hashes, the assertion below fails.
+        let code_bytes = [42u8; CONTRACT_KEY_SIZE];
+
+        let mut builder = flatbuffers::FlatBufferBuilder::new();
+        let instance_data = builder.create_vector(&instance_bytes);
+        let instance_offset = FbsContractInstanceId::create(
+            &mut builder,
+            &ContractInstanceIdArgs {
+                data: Some(instance_data),
+            },
+        );
+        let code = Some(builder.create_vector(&code_bytes));
+        let key_offset = FbsContractKey::create(
+            &mut builder,
+            &ContractKeyArgs {
+                instance: Some(instance_offset),
+                code,
+            },
+        );
+        builder.finish_minimal(key_offset);
+
+        let fbs_key = flatbuffers::root::<FbsContractKey>(builder.finished_data())
+            .expect("valid ContractKey flatbuffer");
+        let decoded = ContractKey::try_decode_fbs(&fbs_key).expect("decode ContractKey");
+
+        assert_eq!(
+            decoded.code_hash().as_ref(),
+            &code_bytes,
+            "decoder must pass the code hash through unchanged, not re-hash it"
+        );
+        assert_eq!(decoded.id().as_bytes(), &instance_bytes);
+    }
 }

--- a/rust/src/contract_interface/key.rs
+++ b/rust/src/contract_interface/key.rs
@@ -237,8 +237,19 @@ impl std::fmt::Display for ContractKey {
 /// reason and have the same remedy.
 ///
 /// The old text was `CodeHash::try_from`'s `io::ErrorKind::InvalidData`, which
-/// stringifies to "invalid data" — nothing a browser developer can act on. Name
+/// stringifies to "invalid data": nothing a browser developer can act on. Name
 /// the field, the expected length, what actually arrived, and why it matters.
+///
+/// Be precise about WHY, because the obvious phrasing is wrong. The node does
+/// NOT resolve a contract's WASM by code hash. It resolves by INSTANCE id:
+/// `ContractStore::fetch_contract` recovers the real hash from
+/// `key_to_code_part[key.id()]`, the module cache keys on `ContractKey` whose
+/// `Hash`/`Eq` use only the instance, and the state stores key on
+/// `as_bytes()`, which is instance bytes. The hash is load-bearing at exactly
+/// one place: the gate that asks whether this node already holds the code
+/// blob. Saying otherwise would tell a reader the hash is fundamentally
+/// required, which is the opposite of what freenet-core#4978 argues, and #4978
+/// is the fix we point them at.
 fn code_hash_error(observed: Option<usize>) -> String {
     let seen = match observed {
         Some(len) => format!("got {len} bytes"),
@@ -246,18 +257,40 @@ fn code_hash_error(observed: Option<usize>) -> String {
     };
     format!(
         "ContractKey.code must be the {CONTRACT_KEY_SIZE}-byte contract code hash; {seen}. \
-         An UPDATE cannot be addressed by instance id alone: the node resolves the \
-         contract's WASM by code hash, so a missing or wrong-length hash is rejected here \
-         instead of failing later as \"Contract not in store and no code provided\". Build \
-         the key with both parts — in the TypeScript SDK use `new ContractKey(instance, \
-         code)` rather than `ContractKey.fromInstanceId(...)`. See freenet/freenet-core#4978."
+         An UPDATE cannot be addressed by instance id alone: the node gates an UPDATE on \
+         already holding the contract's code blob and probes for it by code hash, so a \
+         missing or wrong-length hash is rejected here instead of failing later as \
+         \"missing contract: <key>\". Build the key with both parts: in the TypeScript SDK \
+         use `new ContractKey(instance, code)` rather than \
+         `ContractKey.fromInstanceId(...)`. See freenet/freenet-core#4978."
     )
+}
+
+/// Decode a wire `ContractInstanceId`'s bytes, rejecting a wrong length instead
+/// of panicking.
+///
+/// The flatbuffers verifier checks that a `(required)` vector is PRESENT; it
+/// does not check its LENGTH. So a peer can hand us an 8-byte `instance` that
+/// `flatbuffers::root` happily accepts, and the `try_into().unwrap()` this
+/// replaces then panicked with `TryFromSliceError`. There is no `catch_unwind`
+/// on this path and `panic = "abort"` is not set, so that unwound and killed
+/// the client's connection task: a wire-reachable remote panic.
+pub(crate) fn instance_id_from_fbs(data: &[u8]) -> Result<ContractInstanceId, WsApiError> {
+    let bytes: [u8; CONTRACT_KEY_SIZE] = data.try_into().map_err(|_| {
+        WsApiError::deserialization(format!(
+            "ContractKey.instance must be the {CONTRACT_KEY_SIZE}-byte contract instance id; \
+             got {} bytes. The flatbuffers verifier only checks that this required field is \
+             present, not that it is the right length, so a wrong-length id reaches the \
+             decoder and must be rejected here.",
+            data.len()
+        ))
+    })?;
+    Ok(ContractInstanceId::new(bytes))
 }
 
 impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
     fn try_decode_fbs(key: &FbsContractKey<'a>) -> Result<Self, WsApiError> {
-        let key_bytes: [u8; CONTRACT_KEY_SIZE] = key.instance().data().bytes().try_into().unwrap();
-        let instance = ContractInstanceId::new(key_bytes);
+        let instance = instance_id_from_fbs(key.instance().data().bytes())?;
         // The `code` field carries the already-computed 32-byte code hash
         // (BLAKE3 of the wasm), so pass those bytes straight through. Calling
         // `CodeHash::from_code` here would hash the hash again —
@@ -338,47 +371,32 @@ mod fbs_tests {
     /// UpdateRequest with "Contract not in store and no code provided".
     #[test]
     fn contract_key_code_hash_passes_through_fbs_decode() {
-        let instance_bytes = [7u8; CONTRACT_KEY_SIZE];
         // A distinct, arbitrary code hash. The decoder must reproduce it
         // verbatim; if it re-hashes, the assertion below fails.
         let code_bytes = [42u8; CONTRACT_KEY_SIZE];
-
-        let mut builder = flatbuffers::FlatBufferBuilder::new();
-        let instance_data = builder.create_vector(&instance_bytes);
-        let instance_offset = FbsContractInstanceId::create(
-            &mut builder,
-            &ContractInstanceIdArgs {
-                data: Some(instance_data),
-            },
-        );
-        let code = Some(builder.create_vector(&code_bytes));
-        let key_offset = FbsContractKey::create(
-            &mut builder,
-            &ContractKeyArgs {
-                instance: Some(instance_offset),
-                code,
-            },
-        );
-        builder.finish_minimal(key_offset);
-
-        let fbs_key = flatbuffers::root::<FbsContractKey>(builder.finished_data())
-            .expect("valid ContractKey flatbuffer");
-        let decoded = ContractKey::try_decode_fbs(&fbs_key).expect("decode ContractKey");
+        let decoded = decode_with_code(Some(&code_bytes)).expect("decode ContractKey");
 
         assert_eq!(
             decoded.code_hash().as_ref(),
             &code_bytes,
             "decoder must pass the code hash through unchanged, not re-hash it"
         );
-        assert_eq!(decoded.id().as_bytes(), &instance_bytes);
+        assert_eq!(decoded.id().as_bytes(), &[7u8; CONTRACT_KEY_SIZE]);
     }
 
     /// Build a `ContractKey` flatbuffer whose `code` vector holds `code_bytes`,
     /// or which omits the optional `code` field entirely when `code_bytes` is
     /// `None`, and run it through the decoder.
     fn decode_with_code(code_bytes: Option<&[u8]>) -> Result<ContractKey, WsApiError> {
+        decode_key(&[7u8; CONTRACT_KEY_SIZE], code_bytes)
+    }
+
+    /// Serialize a `ContractKey` flatbuffer with the given raw field bytes.
+    /// Neither vector is length-checked here on purpose: the point is to feed
+    /// the decoder exactly what a peer could put on the wire.
+    fn encode_key(instance_bytes: &[u8], code_bytes: Option<&[u8]>) -> Vec<u8> {
         let mut builder = flatbuffers::FlatBufferBuilder::new();
-        let instance_data = builder.create_vector(&[7u8; CONTRACT_KEY_SIZE]);
+        let instance_data = builder.create_vector(instance_bytes);
         let instance_offset = FbsContractInstanceId::create(
             &mut builder,
             &ContractInstanceIdArgs {
@@ -394,11 +412,92 @@ mod fbs_tests {
             },
         );
         builder.finish_minimal(key_offset);
+        builder.finished_data().to_vec()
+    }
 
-        let bytes = builder.finished_data().to_vec();
+    fn decode_key(
+        instance_bytes: &[u8],
+        code_bytes: Option<&[u8]>,
+    ) -> Result<ContractKey, WsApiError> {
+        let bytes = encode_key(instance_bytes, code_bytes);
         let fbs_key =
             flatbuffers::root::<FbsContractKey>(&bytes).expect("valid ContractKey flatbuffer");
         ContractKey::try_decode_fbs(&fbs_key)
+    }
+
+    /// FIXED BYTES pinning the `common.ContractKey` vtable layout.
+    ///
+    /// Why a blob when the sibling tests build programmatically: a
+    /// programmatic test encodes with the SAME generated code it then decodes
+    /// with, so a `common.fbs` change that reorders `instance` and `code` moves
+    /// both sides together and the test stays green while real TypeScript
+    /// clients break. Only bytes frozen OUTSIDE the generated code catch that.
+    /// This restores a property the PR briefly lost: after rebuilding the
+    /// update fixture programmatically, nothing decoded a `common.ContractKey`
+    /// from fixed bytes at all (the PUT fixture recomputes its key from
+    /// params+code and never reads the table; GET/SUBSCRIBE read only instance
+    /// bytes). Follows `delegate_interface.rs`'s `*_wire_format_is_stable`.
+    ///
+    /// Distinct from the TypeScript-blob test in `client_api::client_events`,
+    /// which pins the REJECT path. This one must pin a SUCCESSFUL decode.
+    ///
+    /// To regenerate after a deliberate schema change: build the same key with
+    /// `encode_key(&[7; 32], Some(&[42; 32]))` and paste `finished_data()`.
+    /// Changing these bytes is a wire-format break; be sure that is intended.
+    const CONTRACT_KEY_WIRE_FORMAT: &[u8] = &[
+        12, 0, 0, 0, 8, 0, 12, 0, 4, 0, 8, 0, 8, 0, 0, 0, 52, 0, 0, 0, 4, 0, 0, 0, 32, 0, 0, 0, 42,
+        42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
+        42, 42, 42, 42, 42, 42, 42, 42, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 32, 0, 0,
+        0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7,
+    ];
+
+    #[test]
+    fn contract_key_wire_format_is_stable() {
+        let fbs_key = flatbuffers::root::<FbsContractKey>(CONTRACT_KEY_WIRE_FORMAT)
+            .expect("the pinned ContractKey bytes must still parse");
+        let decoded = ContractKey::try_decode_fbs(&fbs_key)
+            .expect("the pinned ContractKey bytes must still decode");
+        assert_eq!(
+            decoded.id().as_bytes(),
+            &[7u8; CONTRACT_KEY_SIZE],
+            "instance id moved: `common.ContractKey`'s vtable layout changed, \
+             which breaks every already-deployed client"
+        );
+        assert_eq!(
+            decoded.code_hash().as_ref(),
+            &[42u8; CONTRACT_KEY_SIZE],
+            "code hash moved: `common.ContractKey`'s vtable layout changed, \
+             which breaks every already-deployed client"
+        );
+    }
+
+    /// A wrong-length `instance` is rejected, not panicked on.
+    ///
+    /// `instance`/`data` are `(required)` in the schema, but the flatbuffers
+    /// verifier checks PRESENCE, not LENGTH — so `flatbuffers::root` accepts an
+    /// 8-byte instance and the `try_into().unwrap()` this replaced then panicked
+    /// with `TryFromSliceError`. Nothing catches unwind on this path and
+    /// `panic = "abort"` is not set, so it killed the client's connection task:
+    /// a remote, wire-reachable panic reachable from UPDATE, GET and SUBSCRIBE.
+    #[test]
+    fn contract_key_decode_rejects_short_instance_without_panicking() {
+        let err = decode_key(&[1u8; 8], Some(&[42u8; CONTRACT_KEY_SIZE]))
+            .expect_err("a short instance vector must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ContractKey.instance") && msg.contains("got 8 bytes"),
+            "the error must name the field and the observed length, got: {msg}"
+        );
+    }
+
+    /// An over-long `instance` is rejected too — the guard is a length equality,
+    /// not a minimum, so a peer cannot pad its way past it.
+    #[test]
+    fn contract_key_decode_rejects_long_instance() {
+        let err = decode_key(&[1u8; 64], Some(&[42u8; CONTRACT_KEY_SIZE]))
+            .expect_err("an over-long instance vector must be rejected");
+        assert!(err.to_string().contains("got 64 bytes"), "got: {err}");
     }
 
     /// A zero-length `code` is rejected, and the error says what to do about it.

--- a/rust/src/contract_interface/key.rs
+++ b/rust/src/contract_interface/key.rs
@@ -293,8 +293,8 @@ impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
         let instance = instance_id_from_fbs(key.instance().data().bytes())?;
         // The `code` field carries the already-computed 32-byte code hash
         // (BLAKE3 of the wasm), so pass those bytes straight through. Calling
-        // `CodeHash::from_code` here would hash the hash again —
-        // BLAKE3(BLAKE3(wasm)) — yielding a key that never matches the store and
+        // `CodeHash::from_code` here would hash the hash again -
+        // BLAKE3(BLAKE3(wasm)): yielding a key that never matches the store and
         // breaking every FlatBuffers UpdateRequest ("Contract not in store and
         // no code provided"). GET/SUBSCRIBE dodged this because they decode only
         // the instance id; UPDATE decodes the full key. The delegate decoder
@@ -306,7 +306,7 @@ impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
         // `ContractKey.fromInstanceId(...)` emits a present-but-empty vector.
         // That is a deliberate narrowing, not an oversight: `try_decode_fbs` is
         // reached only from the UPDATE decode path, and an UPDATE genuinely needs
-        // the hash today — freenet-core gates on `code_blob_stored(key.code_hash())`
+        // the hash today: freenet-core gates on `code_blob_stored(key.code_hash())`
         // and, because UPDATE supplies no contract code, a miss fails the request
         // with "Contract not in store and no code provided". So an empty or absent
         // `code` has never produced a working UPDATE; before this change it merely
@@ -475,7 +475,7 @@ mod fbs_tests {
     /// A wrong-length `instance` is rejected, not panicked on.
     ///
     /// `instance`/`data` are `(required)` in the schema, but the flatbuffers
-    /// verifier checks PRESENCE, not LENGTH — so `flatbuffers::root` accepts an
+    /// verifier checks PRESENCE, not LENGTH: so `flatbuffers::root` accepts an
     /// 8-byte instance and the `try_into().unwrap()` this replaced then panicked
     /// with `TryFromSliceError`. Nothing catches unwind on this path and
     /// `panic = "abort"` is not set, so it killed the client's connection task:
@@ -491,7 +491,7 @@ mod fbs_tests {
         );
     }
 
-    /// An over-long `instance` is rejected too — the guard is a length equality,
+    /// An over-long `instance` is rejected too: the guard is a length equality,
     /// not a minimum, so a peer cannot pad its way past it.
     #[test]
     fn contract_key_decode_rejects_long_instance() {
@@ -509,7 +509,7 @@ mod fbs_tests {
     ///    TypeScript SDK's `ContractKey.fromInstanceId(...)` emits exactly this
     ///    shape, so narrowing to "32 bytes or nothing" is a deliberate call, not
     ///    an accident of using `CodeHash::try_from`. It is safe because an
-    ///    UPDATE carrying no code hash could never be served anyway — the node
+    ///    UPDATE carrying no code hash could never be served anyway: the node
     ///    resolves the WASM by code hash and fails at the store gate.
     /// 2. The message. The whole point of rejecting early is diagnosis: the
     ///    previous text was `io::ErrorKind::InvalidData`, which stringifies to
@@ -545,8 +545,8 @@ mod fbs_tests {
     }
 
     /// An absent `code` is rejected the same way. Unreachable from any
-    /// first-party producer — the TypeScript `pack()` always emits the vector
-    /// and the Rust stdlib has no client-to-node FBS request encoder — so this
+    /// first-party producer: the TypeScript `pack()` always emits the vector
+    /// and the Rust stdlib has no client-to-node FBS request encoder: so this
     /// only guards hand-rolled third-party encoders. Behavior is unchanged from
     /// before this PR (it was already rejected); only the message improved, so
     /// what is pinned here is that the two paths stay consistent.

--- a/rust/src/contract_interface/key.rs
+++ b/rust/src/contract_interface/key.rs
@@ -229,6 +229,31 @@ impl std::fmt::Display for ContractKey {
     }
 }
 
+/// Error text for a `ContractKey` whose wire `code` field cannot be read as a
+/// contract code hash.
+///
+/// `observed` is the field's byte length, or `None` when the optional field was
+/// omitted entirely. Both cases share one message because they fail for the same
+/// reason and have the same remedy.
+///
+/// The old text was `CodeHash::try_from`'s `io::ErrorKind::InvalidData`, which
+/// stringifies to "invalid data" — nothing a browser developer can act on. Name
+/// the field, the expected length, what actually arrived, and why it matters.
+fn code_hash_error(observed: Option<usize>) -> String {
+    let seen = match observed {
+        Some(len) => format!("got {len} bytes"),
+        None => "the field was absent".to_string(),
+    };
+    format!(
+        "ContractKey.code must be the {CONTRACT_KEY_SIZE}-byte contract code hash; {seen}. \
+         An UPDATE cannot be addressed by instance id alone: the node resolves the \
+         contract's WASM by code hash, so a missing or wrong-length hash is rejected here \
+         instead of failing later as \"Contract not in store and no code provided\". Build \
+         the key with both parts — in the TypeScript SDK use `new ContractKey(instance, \
+         code)` rather than `ContractKey.fromInstanceId(...)`. See freenet/freenet-core#4978."
+    )
+}
+
 impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
     fn try_decode_fbs(key: &FbsContractKey<'a>) -> Result<Self, WsApiError> {
         let key_bytes: [u8; CONTRACT_KEY_SIZE] = key.instance().data().bytes().try_into().unwrap();
@@ -242,12 +267,31 @@ impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
         // the instance id; UPDATE decodes the full key. The delegate decoder
         // already does the pass-through correctly (see
         // `DelegateKey::try_decode_fbs`). Regression test below.
-        let code = key
+        //
+        // Anything other than exactly `CONTRACT_KEY_SIZE` bytes is rejected here,
+        // even though the schema marks `code` optional and the TypeScript SDK's
+        // `ContractKey.fromInstanceId(...)` emits a present-but-empty vector.
+        // That is a deliberate narrowing, not an oversight: `try_decode_fbs` is
+        // reached only from the UPDATE decode path, and an UPDATE genuinely needs
+        // the hash today — freenet-core gates on `code_blob_stored(key.code_hash())`
+        // and, because UPDATE supplies no contract code, a miss fails the request
+        // with "Contract not in store and no code provided". So an empty or absent
+        // `code` has never produced a working UPDATE; before this change it merely
+        // failed later, at the store gate, with an error pointing at the node
+        // rather than at the caller. Rejecting at the boundary with an actionable
+        // message is strictly better diagnostics for the same outcome.
+        //
+        // The honest end state is `Option<CodeHash>` threaded through
+        // `ContractRequest::Update`, once freenet-core resolves a `None` from the
+        // instance id the way GET and SUBSCRIBE already do via
+        // `code_hash_from_id`. That is tracked in freenet/freenet-core#4978; it
+        // needs a coordinated stdlib + core change, so it is not done here.
+        let code_bytes = key
             .code()
-            .map(|code_hash| CodeHash::try_from(code_hash.bytes()))
-            .transpose()
-            .map_err(|e| WsApiError::deserialization(e.to_string()))?
-            .ok_or_else(|| WsApiError::deserialization("ContractKey missing code hash".into()))?;
+            .map(|code_hash| code_hash.bytes())
+            .ok_or_else(|| WsApiError::deserialization(code_hash_error(None)))?;
+        let code = CodeHash::try_from(code_bytes)
+            .map_err(|_| WsApiError::deserialization(code_hash_error(Some(code_bytes.len()))))?;
         Ok(ContractKey { instance, code })
     }
 }
@@ -327,5 +371,109 @@ mod fbs_tests {
             "decoder must pass the code hash through unchanged, not re-hash it"
         );
         assert_eq!(decoded.id().as_bytes(), &instance_bytes);
+    }
+
+    /// Build a `ContractKey` flatbuffer whose `code` vector holds `code_bytes`,
+    /// or which omits the optional `code` field entirely when `code_bytes` is
+    /// `None`, and run it through the decoder.
+    fn decode_with_code(code_bytes: Option<&[u8]>) -> Result<ContractKey, WsApiError> {
+        let mut builder = flatbuffers::FlatBufferBuilder::new();
+        let instance_data = builder.create_vector(&[7u8; CONTRACT_KEY_SIZE]);
+        let instance_offset = FbsContractInstanceId::create(
+            &mut builder,
+            &ContractInstanceIdArgs {
+                data: Some(instance_data),
+            },
+        );
+        let code = code_bytes.map(|bytes| builder.create_vector(bytes));
+        let key_offset = FbsContractKey::create(
+            &mut builder,
+            &ContractKeyArgs {
+                instance: Some(instance_offset),
+                code,
+            },
+        );
+        builder.finish_minimal(key_offset);
+
+        let bytes = builder.finished_data().to_vec();
+        let fbs_key =
+            flatbuffers::root::<FbsContractKey>(&bytes).expect("valid ContractKey flatbuffer");
+        ContractKey::try_decode_fbs(&fbs_key)
+    }
+
+    /// A zero-length `code` is rejected, and the error says what to do about it.
+    ///
+    /// This pins BOTH halves of the decision, because each is easy to undo
+    /// without noticing the other:
+    ///
+    /// 1. The rejection itself. The schema marks `code` optional and the
+    ///    TypeScript SDK's `ContractKey.fromInstanceId(...)` emits exactly this
+    ///    shape, so narrowing to "32 bytes or nothing" is a deliberate call, not
+    ///    an accident of using `CodeHash::try_from`. It is safe because an
+    ///    UPDATE carrying no code hash could never be served anyway — the node
+    ///    resolves the WASM by code hash and fails at the store gate.
+    /// 2. The message. The whole point of rejecting early is diagnosis: the
+    ///    previous text was `io::ErrorKind::InvalidData`, which stringifies to
+    ///    "invalid data" and told a browser developer nothing. Reverting to a
+    ///    bare `try_from` error would keep this test's first assertion green
+    ///    while destroying the reason the change was made, so the message
+    ///    content is asserted too.
+    #[test]
+    fn contract_key_decode_rejects_empty_code_with_actionable_error() {
+        let err = decode_with_code(Some(&[])).expect_err("empty code must be rejected");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("ContractKey.code"),
+            "error must name the offending field, got: {msg}"
+        );
+        assert!(
+            msg.contains("32-byte"),
+            "error must state the expected length, got: {msg}"
+        );
+        assert!(
+            msg.contains("got 0 bytes"),
+            "error must state the actual length, got: {msg}"
+        );
+        assert!(
+            msg.contains("instance id alone"),
+            "error must explain why the hash is required, got: {msg}"
+        );
+        assert!(
+            msg.contains("4978"),
+            "error must point at the tracking issue for the real fix, got: {msg}"
+        );
+    }
+
+    /// An absent `code` is rejected the same way. Unreachable from any
+    /// first-party producer — the TypeScript `pack()` always emits the vector
+    /// and the Rust stdlib has no client-to-node FBS request encoder — so this
+    /// only guards hand-rolled third-party encoders. Behavior is unchanged from
+    /// before this PR (it was already rejected); only the message improved, so
+    /// what is pinned here is that the two paths stay consistent.
+    #[test]
+    fn contract_key_decode_rejects_absent_code_with_actionable_error() {
+        let err = decode_with_code(None).expect_err("absent code must be rejected");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("ContractKey.code") && msg.contains("4978"),
+            "absent-code error must carry the same guidance as the empty case, got: {msg}"
+        );
+        assert!(
+            msg.contains("absent"),
+            "absent-code error must distinguish itself from a wrong-length one, got: {msg}"
+        );
+    }
+
+    /// A wrong-but-nonzero length is rejected with the length it saw. Guards the
+    /// obvious partial fix of special-casing only the empty vector.
+    #[test]
+    fn contract_key_decode_rejects_wrong_length_code() {
+        let err = decode_with_code(Some(&[1u8; 16])).expect_err("16-byte code must be rejected");
+        assert!(
+            err.to_string().contains("got 16 bytes"),
+            "error must report the observed length, got: {err}"
+        );
     }
 }

--- a/rust/src/contract_interface/mod.rs
+++ b/rust/src/contract_interface/mod.rs
@@ -10,7 +10,7 @@ mod code;
 mod contract;
 pub mod encoding;
 mod error;
-mod key;
+pub(crate) mod key;
 mod state;
 mod trait_def;
 mod update;

--- a/typescript/tests/websocket-interface.test.ts
+++ b/typescript/tests/websocket-interface.test.ts
@@ -345,7 +345,7 @@ describe("Freenet Websocket API - Result Deserialization", () => {
     // probes for it by code hash). This suite therefore asserts an encoding the
     // node will refuse. The Rust side pins that disagreement explicitly in
     // `client_api::client_events::typescript_sdk_instance_only_update_is_rejected_with_guidance`
-    // — if this array changes, that test must change with it, and vice versa.
+    //: if this array changes, that test must change with it, and vice versa.
     // Making `UpdateRequest` require a 32-byte code hash is tracked in
     // freenet/freenet-core#4978.
     // Define the expected Uint8Array request

--- a/typescript/tests/websocket-interface.test.ts
+++ b/typescript/tests/websocket-interface.test.ts
@@ -337,6 +337,17 @@ describe("Freenet Websocket API - Result Deserialization", () => {
   });
 
   test("should correctly generate a ClientRequest for contract update operation", async () => {
+    // NOTE: the Rust decoder REJECTS these bytes. `ContractKey.fromInstanceId`
+    // leaves `code` present but zero-length, and freenet-stdlib's
+    // `ContractKey::try_decode_fbs` now hard-errors on any `code` that is not
+    // exactly 32 bytes, because an UPDATE addressed by instance id alone has
+    // never been servable (the node gates on already holding the code blob and
+    // probes for it by code hash). This suite therefore asserts an encoding the
+    // node will refuse. The Rust side pins that disagreement explicitly in
+    // `client_api::client_events::typescript_sdk_instance_only_update_is_rejected_with_guidance`
+    // — if this array changes, that test must change with it, and vice versa.
+    // Making `UpdateRequest` require a 32-byte code hash is tracked in
+    // freenet/freenet-core#4978.
     // Define the expected Uint8Array request
     let EXPECTED_UPDATE_REQ = new Uint8Array([
       4, 0, 0, 0, 220, 255, 255, 255, 8, 0, 0, 0, 0, 0, 0, 1, 232, 255, 255,


### PR DESCRIPTION
## Problem

`ContractKey::try_decode_fbs` called `CodeHash::from_code(code_hash.bytes())` on the wire `code` field. That field already carries the computed 32-byte code hash, and `from_code` hashes its input — so decoding produced BLAKE3(BLAKE3(wasm)), a key that never matches the store.

Every FBS encode site writes `key.code_hash().0` (the raw 32 bytes), so the wire contract genuinely is "`code` carries the hash" and passing it through is correct. `DelegateKey::try_decode_fbs` already does it that way.

Blast radius: FlatBuffers clients, which is the default for the TypeScript SDK — browser apps. GET and SUBSCRIBE were unaffected because their `ContractRequest` variants carry only an instance id and never decode `code`; UPDATE is the one variant carrying a full `ContractKey`. Affected apps looked healthy until the first write, which surfaced as a 30s timeout rather than an error.

## What this does

1. **Pass the code hash through** instead of re-hashing it.
2. **Reject a `code` field that is not exactly 32 bytes**, with an error a client developer can act on.

## Why reject rather than tolerate

The schema marks `code` optional, and the TypeScript SDK's `ContractKey.fromInstanceId(...)` emits a **present but zero-length** vector — `pack()` always adds the vector, so this is a shape real first-party producers emit, not a hand-built artifact. The old test fixture in this repo carried exactly that shape.

It is nonetheless safe to reject, because such an UPDATE **has never worked**:

- `try_decode_fbs` is reached from exactly one production site, the UPDATE decode (`client_events.rs`).
- freenet-core gates on `code_blob_stored(key.code_hash())` (`contract/executor/runtime/executor_impl.rs:250`), a pure code-hash lookup.
- UPDATE supplies no contract code — `maybe_defer_upsert(..., code: None, ...)` (`contract.rs:2334`).
- So an empty `code` hashed to BLAKE3 of empty input and failed at the store gate with `"Contract not in store and no code provided"`.

**Wire-compat consequence, stated plainly:** this hard-errors a message shape the TypeScript SDK can produce and the schema permits. But every such message was already failing — later, and with an error pointing at the node rather than the caller. No working client regresses. Clients that work today, including the freechan UI that validated the previous commit end to end, all send a real 32-byte hash. What changes for an affected client is a 30s timeout becoming an immediate, explicit error naming the cause.

The error text now carries the field name, the expected length, the observed length, the reason the hash is required, and a pointer to the real fix. The previous text was `io::ErrorKind::InvalidData`, which stringifies to `"invalid data"`.

**The schema is deliberately unchanged.** Marking `code` `(required)` would be a wire break for the absent case and would not help the empty case anyway, since a required field can still be zero-length.

## The real fix, tracked separately

The honest end state is `Option<CodeHash>` threaded through `ContractRequest::Update`, with the node resolving a `None` from the instance id — which it already knows how to do: `code_hash_from_id` exists and is documented for exactly this ("Used when clients request contracts without knowing the code hash"), and GET and SUBSCRIBE already use it via `lookup_key`. UPDATE is the odd one out only because its wire type carries a full key.

That needs a coordinated stdlib + core change, so it is **freenet/freenet-core#4978**, not this PR. Corroboration that it is the right target: `fdev execute update` sends 32 zero bytes with the comment "the node will look up the actual key" (`crates/fdev/src/commands.rs:419-421`), which is false for UPDATE though true for GET.

## Testing

- `contract_key_code_hash_passes_through_fbs_decode` — the double-hash regression.
- `contract_key_decode_rejects_empty_code_with_actionable_error` — pins **both** the rejection and the message content, since reverting to a bare `try_from` error would leave the rejection green while destroying the reason for the change.
- `contract_key_decode_rejects_absent_code_with_actionable_error` — the absent case keeps its pre-existing behavior; only its message changed, so what is pinned is that the two paths stay consistent.
- `contract_key_decode_rejects_wrong_length_code` — guards the partial fix of special-casing only the empty vector.
- `test_build_contract_update_op_from_fbs` — **rebuilt programmatically.** Its hardcoded byte blob is why the empty-`code` case went unnoticed: reading the test told you nothing and finding it took instrumenting the decoder. It now carries a real 32-byte hash and asserts the hash survives decode, so it covers the double-hash regression too; previously it asserted only the instance id.

Mutation-verified both directions: reverting the error message fails the two message-asserting tests, and reintroducing the double-hash fails both the fixture and the pass-through test (the old blob fixture would not have caught it).

`cargo fmt`, `cargo clippy --all-targets --features net -- -D warnings`, and the full suite (61 tests) are clean.

[AI-assisted - Claude]
