### PR TITLE
feat: add DelegateRequest::RegisterDelegateWithPredecessors for secret copy-forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.8.4] - 2026-07-21
+
+### Added
+- **`DelegateRequest::RegisterDelegateWithPredecessors`** — a new client
+  request variant for registering a delegate while requesting a one-shot,
+  node-side copy-forward of the LOCAL-scope secrets belonging to one or more
+  retired delegate generations (`predecessors: Vec<DelegateKey>`) into the new
+  delegate's namespace. This is the wire primitive for consent-gated,
+  one-click delegate migration (freenet-core#4117, freenet-core#2776): the
+  node copies already-sealed secret bytes only, performing no execution of any
+  old delegate WASM. The copy-forward is best-effort over unknown
+  predecessors and idempotent per `(predecessor -> successor)` pair. `cipher`
+  and `nonce` mirror `RegisterDelegate` for field-shape parity and are ignored
+  by the node (as they have been since freenet-core#4140).
+
+  The variant is **appended last** (bincode tag `3`, one past
+  `UnregisterDelegate`), so the encodings of `ApplicationMessages`,
+  `RegisterDelegate`, and `UnregisterDelegate` are byte-for-byte unchanged and
+  older clients keep working. New wire-format pin tests lock all four variant
+  tags to guard against a future reorder. The flatbuffers
+  (`EncodingProtocol::Flatbuffers`) client path is intentionally not extended;
+  the Rust consumers of this feature use the bincode `Native` path.
+
 ## [0.8.3] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,21 @@
   The variant is **appended last** (bincode tag `3`, one past
   `UnregisterDelegate`), so the encodings of `ApplicationMessages`,
   `RegisterDelegate`, and `UnregisterDelegate` are byte-for-byte unchanged and
-  older clients keep working. New wire-format pin tests lock all four variant
-  tags to guard against a future reorder. The flatbuffers
-  (`EncodingProtocol::Flatbuffers`) client path is intentionally not extended;
-  the Rust consumers of this feature use the bincode `Native` path.
+  older clients keep working. New wire-format pin tests freeze the complete
+  bincode byte vector of all four variants (the three pre-existing ones
+  anchored to the shipped `0.8.3` format) to guard against a future reorder or
+  nested-encoding change. The flatbuffers (`EncodingProtocol::Flatbuffers`)
+  client path is intentionally not extended; the Rust consumers of this feature
+  use the bincode `Native` path.
+
+### Fixed
+- **`DelegateRequest::try_decode_fbs` no longer panics on an unknown union
+  discriminant.** The generated flatbuffers verifier accepts any
+  `DelegateRequestType` discriminant it doesn't recognize (`_ => Ok(())`), and
+  the union type field is a raw `u8` a client can set to any value, so a
+  crafted request reached an `unreachable!()` and took down the connection
+  handler. It now returns a clean per-request `DeserializationError` naming the
+  unknown discriminant.
 
 ## [0.8.3] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,14 @@
   use the bincode `Native` path.
 
 ### Fixed
-- **`DelegateRequest::try_decode_fbs` no longer panics on an unknown union
-  discriminant.** The generated flatbuffers verifier accepts any
-  `DelegateRequestType` discriminant it doesn't recognize (`_ => Ok(())`), and
-  the union type field is a raw `u8` a client can set to any value, so a
-  crafted request reached an `unreachable!()` and took down the connection
-  handler. It now returns a clean per-request `DeserializationError` naming the
-  unknown discriminant.
+- **The flatbuffers decode path no longer panics on an unknown union
+  discriminant.** Both `DelegateRequest::try_decode_fbs` and
+  `ContractRequest::try_decode_fbs` matched their generated union type with an
+  `unreachable!()` catch-all, but it IS reachable: the generated verifier
+  accepts any discriminant it doesn't recognize (`_ => Ok(())`), and the union
+  type field is a raw `u8` a client can set to any value, so a crafted request
+  reached the catch-all and took down the connection handler. Both now return a
+  clean per-request `DeserializationError` naming the unknown discriminant.
 
 ## [0.8.3] - 2026-07-10
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -766,7 +766,18 @@ impl<'a> TryFromFbs<&FbsDelegateRequest<'a>> for DelegateRequest<'a> {
                     let key = DelegateKey::try_decode_fbs(&unregister.key())?;
                     DelegateRequest::UnregisterDelegate(key)
                 }
-                _ => unreachable!(),
+                // An unknown union discriminant is reachable, not `unreachable!()`:
+                // the generated flatbuffers verifier accepts any discriminant it
+                // doesn't recognize (`_ => Ok(())`), and the union type field is a
+                // raw `u8` the (public) TS builder can set to any value. Panicking
+                // here would let a single crafted request take down the connection
+                // handler, so return a per-request error instead.
+                other => {
+                    return Err(WsApiError::deserialization(format!(
+                        "unknown DelegateRequestType discriminant: {}",
+                        other.0
+                    )));
+                }
             }
         };
 
@@ -2029,7 +2040,8 @@ mod delegate_request_wire_format {
     use super::DelegateRequest;
     use crate::code_hash::CodeHash;
     use crate::prelude::{
-        Delegate, DelegateCode, DelegateContainer, DelegateKey, DelegateWasmAPIVersion, Parameters,
+        ApplicationMessage, Delegate, DelegateCode, DelegateContainer, DelegateKey,
+        DelegateWasmAPIVersion, InboundDelegateMsg, Parameters,
     };
 
     fn sample_container() -> DelegateContainer {
@@ -2042,60 +2054,160 @@ mod delegate_request_wire_format {
         DelegateKey::new([fill; 32], CodeHash::new([fill.wrapping_add(1); 32]))
     }
 
-    /// (a) Byte-stability pin: the three variants that existed before
-    /// `RegisterDelegateWithPredecessors` must keep their exact tags. The
-    /// tag is the first 4 bytes of the bincode encoding; asserting it against
-    /// hardcoded bytes proves appending the new variant did not shift them.
-    /// Modeled on `delegate_interface.rs::inbound_delegate_msg_wire_format_is_stable`
-    /// (tag-prefix pin for the complex variants) and
-    /// `delegate_origin_wire_format_is_stable` (full-byte pin for the simple
-    /// one).
-    #[test]
-    fn existing_variant_tags_are_stable() {
-        // Variant 0: ApplicationMessages.
-        let app = DelegateRequest::ApplicationMessages {
-            key: sample_key(0x11),
-            params: Parameters::from(vec![]),
-            inbound: vec![],
-        };
-        assert_eq!(
-            bincode::serialize(&app).unwrap()[..4],
-            [0, 0, 0, 0],
-            "ApplicationMessages must stay at variant tag 0; reordering \
-             DelegateRequest is a wire-format break"
-        );
+    // The four sample values whose complete bincode encodings are frozen in
+    // `wire_format_is_frozen`. Kept byte-for-byte identical to the throwaway
+    // generator that produced the frozen vectors, so the freeze is
+    // reproducible: construct the value, `bincode::serialize`, compare.
+    fn sample_app_messages() -> DelegateRequest<'static> {
+        DelegateRequest::ApplicationMessages {
+            key: DelegateKey::new([0x11; 32], CodeHash::new([0x22; 32])),
+            params: Parameters::from(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+            inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(vec![0x01, 0x02, 0x03]),
+            )],
+        }
+    }
 
-        // Variant 1: RegisterDelegate.
-        let register = DelegateRequest::RegisterDelegate {
+    fn sample_register() -> DelegateRequest<'static> {
+        DelegateRequest::RegisterDelegate {
             delegate: sample_container(),
             cipher: [0x55; 32],
             nonce: [0x66; 24],
-        };
-        assert_eq!(
-            bincode::serialize(&register).unwrap()[..4],
-            [1, 0, 0, 0],
-            "RegisterDelegate must stay at variant tag 1"
-        );
-
-        // Variant 2: UnregisterDelegate. Simple enough to pin the FULL byte
-        // layout: tag (4) + DelegateKey (32-byte key + 32-byte code_hash,
-        // both fixed-size arrays with no length prefix).
-        let unregister = DelegateRequest::UnregisterDelegate(DelegateKey::new(
-            [0x11; 32],
-            CodeHash::new([0x22; 32]),
-        ));
-        let mut expected = vec![2u8, 0, 0, 0];
-        expected.extend_from_slice(&[0x11; 32]);
-        expected.extend_from_slice(&[0x22; 32]);
-        assert_eq!(
-            bincode::serialize(&unregister).unwrap(),
-            expected,
-            "UnregisterDelegate wire layout (tag 2 + DelegateKey) must be stable"
-        );
+        }
     }
 
-    /// (c) The new variant's tag is exactly `3u32` little-endian. This is the
-    /// direct assertion that it was appended at the end, one past
+    fn sample_unregister() -> DelegateRequest<'static> {
+        DelegateRequest::UnregisterDelegate(DelegateKey::new([0x11; 32], CodeHash::new([0x22; 32])))
+    }
+
+    fn sample_register_with_predecessors() -> DelegateRequest<'static> {
+        DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: sample_container(),
+            cipher: [0x33; 32],
+            nonce: [0x44; 24],
+            predecessors: vec![sample_key(0xA0), sample_key(0xB0), sample_key(0xC0)],
+        }
+    }
+
+    /// Complete-byte wire-format freeze for all four variants.
+    ///
+    /// The three pre-existing variants (`ApplicationMessages`,
+    /// `RegisterDelegate`, `UnregisterDelegate`) are pinned to their FULL
+    /// expected byte vectors — not just the 4-byte tag — so a field reorder or
+    /// a change to a nested type's encoding (e.g. `DelegateContainer`,
+    /// `DelegateKey`, `ApplicationMessage`) is caught, not only a variant
+    /// reorder. Those three vectors were generated from **origin/main @
+    /// 8b53702** (the shipped format) via a throwaway generator and confirmed
+    /// byte-identical to this branch's output, so the pin anchors to what old
+    /// clients actually speak. The fourth vector
+    /// (`RegisterDelegateWithPredecessors`, multi-predecessor list) was
+    /// generated from THIS branch.
+    ///
+    /// The test also DESERIALIZES each frozen vector, proving an old-format
+    /// byte stream still decodes into the expected variant on this build.
+    #[test]
+    fn wire_format_is_frozen() {
+        // --- origin/main @ 8b53702 (shipped format) ---
+        const APP_MESSAGES: &[u8] = &[
+            0, 0, 0, 0, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+            17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 34, 34, 34, 34, 34, 34, 34, 34, 34,
+            34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
+            34, 4, 0, 0, 0, 0, 0, 0, 0, 222, 173, 190, 239, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+            0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        const REGISTER: &[u8] = &[
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 9, 8, 7, 4, 0, 0, 0, 0, 0,
+            0, 0, 1, 2, 3, 4, 99, 120, 29, 23, 20, 37, 163, 99, 18, 250, 5, 141, 135, 18, 213, 208,
+            81, 53, 169, 145, 236, 32, 53, 28, 233, 214, 92, 219, 25, 160, 84, 50, 88, 111, 44, 39,
+            24, 219, 97, 92, 222, 20, 205, 248, 149, 154, 214, 38, 193, 144, 31, 141, 32, 222, 49,
+            197, 66, 237, 16, 98, 165, 72, 6, 11, 99, 120, 29, 23, 20, 37, 163, 99, 18, 250, 5,
+            141, 135, 18, 213, 208, 81, 53, 169, 145, 236, 32, 53, 28, 233, 214, 92, 219, 25, 160,
+            84, 50, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
+            85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 85, 102, 102, 102, 102, 102, 102, 102, 102,
+            102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
+        ];
+        const UNREGISTER: &[u8] = &[
+            2, 0, 0, 0, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+            17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 34, 34, 34, 34, 34, 34, 34, 34, 34,
+            34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
+            34,
+        ];
+        // --- this branch (the new variant) ---
+        const REGISTER_WITH_PREDECESSORS: &[u8] = &[
+            3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 9, 8, 7, 4, 0, 0, 0, 0, 0,
+            0, 0, 1, 2, 3, 4, 99, 120, 29, 23, 20, 37, 163, 99, 18, 250, 5, 141, 135, 18, 213, 208,
+            81, 53, 169, 145, 236, 32, 53, 28, 233, 214, 92, 219, 25, 160, 84, 50, 88, 111, 44, 39,
+            24, 219, 97, 92, 222, 20, 205, 248, 149, 154, 214, 38, 193, 144, 31, 141, 32, 222, 49,
+            197, 66, 237, 16, 98, 165, 72, 6, 11, 99, 120, 29, 23, 20, 37, 163, 99, 18, 250, 5,
+            141, 135, 18, 213, 208, 81, 53, 169, 145, 236, 32, 53, 28, 233, 214, 92, 219, 25, 160,
+            84, 50, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51,
+            51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
+            68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 3, 0, 0, 0, 0, 0, 0, 0, 160,
+            160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160,
+            160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 161, 161, 161,
+            161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161,
+            161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 161, 176, 176, 176, 176, 176,
+            176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 176,
+            176, 176, 176, 176, 176, 176, 176, 176, 176, 176, 177, 177, 177, 177, 177, 177, 177,
+            177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177, 177,
+            177, 177, 177, 177, 177, 177, 177, 177, 192, 192, 192, 192, 192, 192, 192, 192, 192,
+            192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192,
+            192, 192, 192, 192, 192, 192, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193,
+            193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193, 193,
+            193, 193, 193, 193,
+        ];
+
+        // 1. Serialization is byte-stable for every variant.
+        assert_eq!(
+            bincode::serialize(&sample_app_messages()).unwrap(),
+            APP_MESSAGES,
+            "ApplicationMessages (tag 0) encoding changed"
+        );
+        assert_eq!(
+            bincode::serialize(&sample_register()).unwrap(),
+            REGISTER,
+            "RegisterDelegate (tag 1) encoding changed"
+        );
+        assert_eq!(
+            bincode::serialize(&sample_unregister()).unwrap(),
+            UNREGISTER,
+            "UnregisterDelegate (tag 2) encoding changed"
+        );
+        assert_eq!(
+            bincode::serialize(&sample_register_with_predecessors()).unwrap(),
+            REGISTER_WITH_PREDECESSORS,
+            "RegisterDelegateWithPredecessors (tag 3) encoding changed"
+        );
+
+        // 2. The four variant tags are exactly 0,1,2,3 — appending the new
+        //    variant did not shift the pre-existing three.
+        assert_eq!(APP_MESSAGES[..4], 0u32.to_le_bytes());
+        assert_eq!(REGISTER[..4], 1u32.to_le_bytes());
+        assert_eq!(UNREGISTER[..4], 2u32.to_le_bytes());
+        assert_eq!(REGISTER_WITH_PREDECESSORS[..4], 3u32.to_le_bytes());
+
+        // 3. Each frozen (old-format) byte stream still DECODES into its
+        //    variant on this build — an old client's bytes remain readable.
+        assert!(matches!(
+            bincode::deserialize::<DelegateRequest>(APP_MESSAGES).unwrap(),
+            DelegateRequest::ApplicationMessages { .. }
+        ));
+        assert!(matches!(
+            bincode::deserialize::<DelegateRequest>(REGISTER).unwrap(),
+            DelegateRequest::RegisterDelegate { .. }
+        ));
+        assert!(matches!(
+            bincode::deserialize::<DelegateRequest>(UNREGISTER).unwrap(),
+            DelegateRequest::UnregisterDelegate(_)
+        ));
+        assert!(matches!(
+            bincode::deserialize::<DelegateRequest>(REGISTER_WITH_PREDECESSORS).unwrap(),
+            DelegateRequest::RegisterDelegateWithPredecessors { .. }
+        ));
+    }
+
+    /// The new variant's tag is exactly `3u32` little-endian — a direct,
+    /// self-documenting assertion that it was appended one past
     /// `UnregisterDelegate` (tag 2).
     #[test]
     fn register_with_predecessors_tag_is_three() {
@@ -2112,9 +2224,8 @@ mod delegate_request_wire_format {
         );
     }
 
-    /// (b) The new variant round-trips through bincode, including a
-    /// multi-element `predecessors` list (the skip-generations case the
-    /// variant exists for).
+    /// The new variant round-trips through bincode, including a multi-element
+    /// `predecessors` list (the skip-generations case the variant exists for).
     #[test]
     fn register_with_predecessors_round_trips() {
         let predecessors = vec![sample_key(0xA0), sample_key(0xB0), sample_key(0xC0)];
@@ -2163,5 +2274,67 @@ mod delegate_request_wire_format {
             predecessors: vec![sample_key(0xA0)],
         };
         assert_eq!(req.key(), &expected_key);
+    }
+
+    /// The flatbuffers decode path must NOT panic on an unknown
+    /// `DelegateRequestType` discriminant. The generated union verifier accepts
+    /// any discriminant it doesn't recognize (`_ => Ok(())`), and the union
+    /// type field is a raw `u8` that the public (TypeScript) builder can set to
+    /// any value, so a crafted request reaches `DelegateRequest::try_decode_fbs`
+    /// with an out-of-range discriminant. Before the fix this hit
+    /// `unreachable!()` and took down the connection handler; now it is a clean
+    /// per-request error. (Regression guard for the P2 finding on PR #86.)
+    #[test]
+    fn fbs_decode_rejects_unknown_discriminant() {
+        use crate::client_api::TryFromFbs;
+        use crate::generated::client_request::{
+            finish_client_request_buffer, root_as_client_request,
+            ClientRequest as FbsClientRequest, ClientRequestArgs, ClientRequestType,
+            DelegateKey as FbsDelegateKey, DelegateKeyArgs, DelegateRequest as FbsDelegateRequest,
+            DelegateRequestArgs, DelegateRequestType, UnregisterDelegate, UnregisterDelegateArgs,
+        };
+
+        let mut b = flatbuffers::FlatBufferBuilder::new();
+        // A real, well-formed UnregisterDelegate table to hang off the union...
+        let key = b.create_vector(&[0u8; 32]);
+        let code_hash = b.create_vector(&[0u8; 32]);
+        let dk = FbsDelegateKey::create(
+            &mut b,
+            &DelegateKeyArgs {
+                key: Some(key),
+                code_hash: Some(code_hash),
+            },
+        );
+        let unreg = UnregisterDelegate::create(&mut b, &UnregisterDelegateArgs { key: Some(dk) });
+        // ...but LIE about the union type: 99 is past the max known
+        // discriminant (UnregisterDelegate = 3), yet the verifier accepts it.
+        let dreq = FbsDelegateRequest::create(
+            &mut b,
+            &DelegateRequestArgs {
+                delegate_request_type: DelegateRequestType(99),
+                delegate_request: Some(unreg.as_union_value()),
+            },
+        );
+        let creq = FbsClientRequest::create(
+            &mut b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType::DelegateRequest,
+                client_request: Some(dreq.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(&mut b, creq);
+        let bytes = b.finished_data().to_vec();
+
+        let client =
+            root_as_client_request(&bytes).expect("verifier accepts an unknown union discriminant");
+        let fbs_delegate = client
+            .client_request_as_delegate_request()
+            .expect("client_request is a DelegateRequest");
+        let decoded = DelegateRequest::try_decode_fbs(&fbs_delegate);
+        assert!(
+            decoded.is_err(),
+            "an unknown DelegateRequestType discriminant must be a clean \
+             per-request error, never a panic that downs the connection handler"
+        );
     }
 }

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -578,6 +578,35 @@ pub enum DelegateRequest<'a> {
         nonce: [u8; 24],
     },
     UnregisterDelegate(DelegateKey),
+    /// Registers a delegate AND requests a one-shot, node-side copy-forward of
+    /// the LOCAL-scope secrets belonging to `predecessors` into the newly
+    /// registered delegate's own secret namespace.
+    ///
+    /// `predecessors` are the delegate keys of retired generations of this
+    /// delegate. It is a **list** because a user may skip one or more
+    /// generations between the version they last ran and the current one, so
+    /// several prior namespaces can need forwarding in a single registration.
+    /// The copy-forward is:
+    ///   - **consent-gated on the client side** — the node performs NO
+    ///     execution of any old delegate WASM; it only copies the
+    ///     already-sealed LOCAL-scope secret bytes it holds for a predecessor
+    ///     into the successor's namespace,
+    ///   - **best-effort over unknown predecessors** — the server silently
+    ///     ignores any predecessor key it does not hold, and
+    ///   - **idempotent per `(predecessor -> successor)` pair** —
+    ///     re-registering with the same predecessors copies nothing new.
+    ///
+    /// `cipher` and `nonce` mirror [`DelegateRequest::RegisterDelegate`] purely
+    /// for field-shape parity. The node has ignored both since
+    /// freenet-core#4140 (secrets are sealed client-side), so they carry no
+    /// behavior here either; they exist only so the two registration variants
+    /// stay structurally identical.
+    RegisterDelegateWithPredecessors {
+        delegate: DelegateContainer,
+        cipher: [u8; 32],
+        nonce: [u8; 24],
+        predecessors: Vec<DelegateKey>,
+    },
 }
 
 impl DelegateRequest<'_> {
@@ -602,6 +631,17 @@ impl DelegateRequest<'_> {
                 nonce,
             },
             DelegateRequest::UnregisterDelegate(key) => DelegateRequest::UnregisterDelegate(key),
+            DelegateRequest::RegisterDelegateWithPredecessors {
+                delegate,
+                cipher,
+                nonce,
+                predecessors,
+            } => DelegateRequest::RegisterDelegateWithPredecessors {
+                delegate,
+                cipher,
+                nonce,
+                predecessors,
+            },
         }
     }
 
@@ -610,6 +650,7 @@ impl DelegateRequest<'_> {
             DelegateRequest::ApplicationMessages { key, .. } => key,
             DelegateRequest::RegisterDelegate { delegate, .. } => delegate.key(),
             DelegateRequest::UnregisterDelegate(key) => key,
+            DelegateRequest::RegisterDelegateWithPredecessors { delegate, .. } => delegate.key(),
         }
     }
 }
@@ -658,6 +699,18 @@ impl Display for ClientRequest<'_> {
                 }
                 DelegateRequest::UnregisterDelegate(key) => {
                     write!(f, "DelegateRequest::UnregisterDelegate for key `{key}`")
+                }
+                DelegateRequest::RegisterDelegateWithPredecessors {
+                    delegate,
+                    predecessors,
+                    ..
+                } => {
+                    write!(
+                        f,
+                        "DelegateRequest::RegisterDelegateWithPredecessors for delegate.key()=`{}` with {} predecessor(s)",
+                        delegate.key(),
+                        predecessors.len()
+                    )
                 }
             },
             ClientRequest::Disconnect { .. } => write!(f, "client disconnected"),
@@ -1953,5 +2006,162 @@ mod client_request_test {
         }
 
         Ok(())
+    }
+}
+
+/// Wire-format pins for [`DelegateRequest`].
+///
+/// `DelegateRequest` crosses the client<->node boundary as bincode (the
+/// `EncodingProtocol::Native` path in freenet-core; the Rust clients in this
+/// crate — `browser.rs` and `regular.rs` — both `bincode::serialize` their
+/// requests). Bincode encodes an enum's variant as a 4-byte little-endian
+/// `u32` discriminant, so the *order* of the variants is the wire contract:
+/// reordering or inserting a variant anywhere but the end silently reassigns
+/// every following tag and breaks already-deployed clients (the v0.2.11
+/// break class).
+///
+/// `RegisterDelegateWithPredecessors` was appended as the LAST variant
+/// precisely so the three pre-existing tags stay byte-identical. These tests
+/// exist because, before this module, `DelegateRequest` had NO wire-format
+/// pin at all — a reorder would have shipped undetected.
+#[cfg(test)]
+mod delegate_request_wire_format {
+    use super::DelegateRequest;
+    use crate::code_hash::CodeHash;
+    use crate::prelude::{
+        Delegate, DelegateCode, DelegateContainer, DelegateKey, DelegateWasmAPIVersion, Parameters,
+    };
+
+    fn sample_container() -> DelegateContainer {
+        let code = DelegateCode::from(vec![1u8, 2, 3, 4]);
+        let params = Parameters::from(vec![9u8, 8, 7]);
+        DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate::from((&code, &params))))
+    }
+
+    fn sample_key(fill: u8) -> DelegateKey {
+        DelegateKey::new([fill; 32], CodeHash::new([fill.wrapping_add(1); 32]))
+    }
+
+    /// (a) Byte-stability pin: the three variants that existed before
+    /// `RegisterDelegateWithPredecessors` must keep their exact tags. The
+    /// tag is the first 4 bytes of the bincode encoding; asserting it against
+    /// hardcoded bytes proves appending the new variant did not shift them.
+    /// Modeled on `delegate_interface.rs::inbound_delegate_msg_wire_format_is_stable`
+    /// (tag-prefix pin for the complex variants) and
+    /// `delegate_origin_wire_format_is_stable` (full-byte pin for the simple
+    /// one).
+    #[test]
+    fn existing_variant_tags_are_stable() {
+        // Variant 0: ApplicationMessages.
+        let app = DelegateRequest::ApplicationMessages {
+            key: sample_key(0x11),
+            params: Parameters::from(vec![]),
+            inbound: vec![],
+        };
+        assert_eq!(
+            bincode::serialize(&app).unwrap()[..4],
+            [0, 0, 0, 0],
+            "ApplicationMessages must stay at variant tag 0; reordering \
+             DelegateRequest is a wire-format break"
+        );
+
+        // Variant 1: RegisterDelegate.
+        let register = DelegateRequest::RegisterDelegate {
+            delegate: sample_container(),
+            cipher: [0x55; 32],
+            nonce: [0x66; 24],
+        };
+        assert_eq!(
+            bincode::serialize(&register).unwrap()[..4],
+            [1, 0, 0, 0],
+            "RegisterDelegate must stay at variant tag 1"
+        );
+
+        // Variant 2: UnregisterDelegate. Simple enough to pin the FULL byte
+        // layout: tag (4) + DelegateKey (32-byte key + 32-byte code_hash,
+        // both fixed-size arrays with no length prefix).
+        let unregister = DelegateRequest::UnregisterDelegate(DelegateKey::new(
+            [0x11; 32],
+            CodeHash::new([0x22; 32]),
+        ));
+        let mut expected = vec![2u8, 0, 0, 0];
+        expected.extend_from_slice(&[0x11; 32]);
+        expected.extend_from_slice(&[0x22; 32]);
+        assert_eq!(
+            bincode::serialize(&unregister).unwrap(),
+            expected,
+            "UnregisterDelegate wire layout (tag 2 + DelegateKey) must be stable"
+        );
+    }
+
+    /// (c) The new variant's tag is exactly `3u32` little-endian. This is the
+    /// direct assertion that it was appended at the end, one past
+    /// `UnregisterDelegate` (tag 2).
+    #[test]
+    fn register_with_predecessors_tag_is_three() {
+        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: sample_container(),
+            cipher: [0; 32],
+            nonce: [0; 24],
+            predecessors: vec![],
+        };
+        assert_eq!(
+            bincode::serialize(&req).unwrap()[..4],
+            3u32.to_le_bytes(),
+            "RegisterDelegateWithPredecessors must be the 4th variant (tag 3)"
+        );
+    }
+
+    /// (b) The new variant round-trips through bincode, including a
+    /// multi-element `predecessors` list (the skip-generations case the
+    /// variant exists for).
+    #[test]
+    fn register_with_predecessors_round_trips() {
+        let predecessors = vec![sample_key(0xA0), sample_key(0xB0), sample_key(0xC0)];
+        let delegate = sample_container();
+        let expected_key = delegate.key().clone();
+
+        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate,
+            cipher: [0x33; 32],
+            nonce: [0x44; 24],
+            predecessors: predecessors.clone(),
+        };
+
+        let bytes = bincode::serialize(&req).unwrap();
+        let decoded: DelegateRequest = bincode::deserialize(&bytes).unwrap();
+
+        match decoded {
+            DelegateRequest::RegisterDelegateWithPredecessors {
+                delegate,
+                cipher,
+                nonce,
+                predecessors: got,
+            } => {
+                assert_eq!(delegate.key(), &expected_key, "delegate preserved");
+                assert_eq!(cipher, [0x33; 32], "cipher preserved");
+                assert_eq!(nonce, [0x44; 24], "nonce preserved");
+                assert_eq!(
+                    got, predecessors,
+                    "full predecessor list preserved in order"
+                );
+            }
+            other => panic!("round-trip produced the wrong variant: {other:?}"),
+        }
+    }
+
+    /// `key()` returns the newly-registered delegate's key (not a
+    /// predecessor's), matching `RegisterDelegate`'s behavior.
+    #[test]
+    fn key_returns_the_new_delegate() {
+        let delegate = sample_container();
+        let expected_key = delegate.key().clone();
+        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate,
+            cipher: [0; 32],
+            nonce: [0; 24],
+            predecessors: vec![sample_key(0xA0)],
+        };
+        assert_eq!(req.key(), &expected_key);
     }
 }

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -548,7 +548,18 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                         .map(|summary_data| StateSummary::from(summary_data.bytes()));
                     ContractRequest::Subscribe { key, summary }
                 }
-                _ => unreachable!(),
+                // Reachable, not `unreachable!()`: the generated flatbuffers
+                // verifier accepts any unknown union discriminant (`_ => Ok(())`)
+                // and the union type field is a raw `u8` a client can set freely,
+                // so a crafted request reaches here. Return a per-request error
+                // instead of panicking the connection handler. (Mirrors the same
+                // fix on `DelegateRequest::try_decode_fbs`.)
+                other => {
+                    return Err(WsApiError::deserialization(format!(
+                        "unknown ContractRequestType discriminant: {}",
+                        other.0
+                    )));
+                }
             }
         };
 
@@ -2017,6 +2028,64 @@ mod client_request_test {
         }
 
         Ok(())
+    }
+
+    /// The flatbuffers decode path must NOT panic on an unknown
+    /// `ContractRequestType` discriminant. Same class as the `DelegateRequest`
+    /// guard: the generated union verifier accepts any discriminant it doesn't
+    /// recognize (`_ => Ok(())`), and the union type field is a raw `u8` a
+    /// client can set to any value. Before the fix this hit `unreachable!()`
+    /// and downed the connection handler; now it is a clean per-request error.
+    #[test]
+    fn fbs_decode_rejects_unknown_contract_discriminant() {
+        use crate::generated::client_request::{
+            finish_client_request_buffer, ClientRequest as FbsClientRequest, ClientRequestArgs,
+            ClientRequestType, ContractRequest as FbsContractRequest, ContractRequestArgs,
+            ContractRequestType, DelegateKey as FbsDelegateKey, DelegateKeyArgs,
+            UnregisterDelegate, UnregisterDelegateArgs,
+        };
+
+        let mut b = flatbuffers::FlatBufferBuilder::new();
+        // Any well-formed table satisfies the required union value; the
+        // discriminant is unknown so the verifier never inspects it.
+        let key = b.create_vector(&[0u8; 32]);
+        let code_hash = b.create_vector(&[0u8; 32]);
+        let dk = FbsDelegateKey::create(
+            &mut b,
+            &DelegateKeyArgs {
+                key: Some(key),
+                code_hash: Some(code_hash),
+            },
+        );
+        let dummy = UnregisterDelegate::create(&mut b, &UnregisterDelegateArgs { key: Some(dk) });
+        // 99 is past the max known ContractRequestType (Subscribe = 4).
+        let contract = FbsContractRequest::create(
+            &mut b,
+            &ContractRequestArgs {
+                contract_request_type: ContractRequestType(99),
+                contract_request: Some(dummy.as_union_value()),
+            },
+        );
+        let client = FbsClientRequest::create(
+            &mut b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType::ContractRequest,
+                client_request: Some(contract.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(&mut b, client);
+        let bytes = b.finished_data().to_vec();
+
+        let client =
+            root_as_client_request(&bytes).expect("verifier accepts an unknown union discriminant");
+        let fbs_contract = client
+            .client_request_as_contract_request()
+            .expect("client_request is a ContractRequest");
+        assert!(
+            ContractRequest::try_decode_fbs(&fbs_contract).is_err(),
+            "an unknown ContractRequestType discriminant must be a clean \
+             per-request error, never a panic that downs the connection handler"
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

There is no wire primitive for the consent-gated, one-click delegate migration flow (freenet-core#4117, freenet-core#2776). When a delegate's WASM changes its key changes, so the new generation starts with an empty secret namespace and users lose their delegate-held data unless secrets can be forwarded from the retired generation(s) into the new one. This PR adds the client-request primitive that carries the migration intent to the node.

## Approach

Add a **new** `DelegateRequest` variant rather than adding a field to the existing `RegisterDelegate`:

```rust
RegisterDelegateWithPredecessors {
    delegate: DelegateContainer,
    cipher: [u8; 32],
    nonce: [u8; 24],
    predecessors: Vec<DelegateKey>,
}
```

### Why a new variant, not a new field (the compat rationale)

`DelegateRequest` crosses the client↔node boundary as **bincode** (`EncodingProtocol::Native`). Bincode encodes an enum variant as a **4-byte little-endian `u32` discriminant** followed by the fields in declaration order. Two consequences drive the design:

- **Adding a field to `RegisterDelegate` is a wire break.** It changes that variant's byte layout, so any already-deployed client speaking the old shape fails to round-trip — the v0.2.11 break class.
- **Appending a whole new variant as the LAST arm is additive.** The tags of `ApplicationMessages` (0), `RegisterDelegate` (1) and `UnregisterDelegate` (2) stay **byte-for-byte identical**; the new variant takes tag **3**. Old clients that never emit it are unaffected; the node accepts it additively. An old node that receives the new variant fails that one request with a clean `DeserializationError` and keeps the connection alive (confirmed by external review).

`predecessors` is a **list** because a user may skip one or more generations between the version they last ran and the current one, so several prior namespaces can need forwarding in a single registration. The node-side copy-forward (implemented separately in freenet-core#4117) is:
- **consent-gated client-side** — the node executes no old delegate WASM; it copies only the already-sealed LOCAL-scope secret bytes it holds for a predecessor,
- **best-effort over unknown predecessors** — the server silently ignores any predecessor key it does not hold, and
- **idempotent per `(predecessor → successor)` pair**.

`cipher`/`nonce` mirror `RegisterDelegate` purely for field-shape parity; the node has ignored both since freenet-core#4140 (secrets are sealed client-side).

### Flatbuffers path intentionally not extended

The `.fbs` schema and generated code are untouched and the `DelegateRequest::try_decode_fbs` known-variant arms are unchanged. The Rust consumers of this feature (river CLI via `regular.rs`, river UI via `browser.rs`) both `bincode::serialize` their requests, so the feature travels on the **Native** path. A flatbuffers (`EncodingProtocol::Flatbuffers`, TS SDK) client cannot encode a union member absent from the schema, so it cannot construct this variant at all. This also keeps the PR clear of the finicky flatc regen handled separately by `fix/4747-stdlib-flatc-regen`.

## Wire-format pin tests (byte-freeze + provenance)

`DelegateRequest` had **no** wire-format pin before this PR — a variant reorder would have shipped undetected. `wire_format_is_frozen` now freezes the **complete** bincode byte vector of all four variants with non-trivial payloads (a real `ApplicationMessage` + params; a multi-element `predecessors` list), asserts the four tags are exactly 0/1/2/3, and additionally **deserializes** each frozen vector to prove an old-format byte stream still decodes into the expected variant.

**Provenance:** the three pre-existing variants' frozen vectors were generated from **origin/main @ 8b53702** (the shipped `0.8.3` format) via a throwaway generator and confirmed byte-identical to this branch, so the pin anchors to what old clients actually speak. The fourth vector (`RegisterDelegateWithPredecessors`) was generated from this branch. This is stated in a comment in the test.

## Reachable-panic hardening (both client-request fbs unions)

Pre-existing, surfaced by review on the exact line this PR's rationale cites. Both `DelegateRequest::try_decode_fbs` and `ContractRequest::try_decode_fbs` matched their generated union type with an `unreachable!()` catch-all — but it **is** reachable: the generated verifier accepts any discriminant it doesn't recognize (`_ => Ok(())`), and the union type field is a raw `u8` the public (TypeScript) builder can set to any value, so a single crafted request reached the catch-all and **panicked the connection handler** (a DoS). Both now return a clean per-request `DeserializationError` naming the unknown discriminant.

Two regression tests build a `ClientRequest` buffer with an out-of-range discriminant (99) via the generated flatbuffers builders and assert a clean `Err` (no panic) — one for each union.

## Testing

- `wire_format_is_frozen` — complete-byte freeze + tag pins + deserialize-old-bytes for all four variants.
- `register_with_predecessors_tag_is_three` — the new variant serializes at tag `3u32` LE.
- `register_with_predecessors_round_trips` — bincode round-trip including a multi-element `predecessors` list.
- `key_returns_the_new_delegate` — `key()` returns the newly-registered delegate's key.
- `fbs_decode_rejects_unknown_discriminant` / `fbs_decode_rejects_unknown_contract_discriminant` — crafted unknown-discriminant buffers return `Err`, not a panic.

`cargo fmt`, `cargo clippy` (x86_64 + wasm32, and `--all-targets`), and the full `cargo test --workspace --features contract,net,testing,trace` suite are green. Bumps `freenet-stdlib` 0.8.3 → 0.8.4.

## Review lineage

External Codex pass: compat verdict clean (existing bytes unchanged; old-node failure is a clean per-request `DeserializationError` with the connection kept alive). It raised two findings, both addressed here: **P1** — freeze complete byte vectors for all four variants (was tag-only for the complex ones) + deserialize the frozen old vectors, anchored to origin/main; **P2** — replace the reachable `unreachable!()` in the fbs decode, and (per maintainer direction) fold in the identical `ContractRequest` sibling in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wJpXbgCrnkSKgkpmnLGwQ

[AI-assisted - Claude]