### PR TITLE
fix: stop the flatbuffers decode boundary panicking on client input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 ## [Unreleased]
 
 ### Fixed
+- **Related-contract decoding no longer panics on well-formed requests.**
+  `RelatedStateUpdate.related_to`, `RelatedDeltaUpdate.related_to`,
+  `RelatedStateAndDeltaUpdate.related_to` and `RelatedContract.instance_id`
+  were decoded with `ContractInstanceId::from_bytes(..).unwrap()`. That
+  function is a **base58 string decoder**, and the wire carries the id as 32
+  raw bytes. This was not an edge case: a random 32-byte id essentially never
+  consists solely of base58 characters (the alphabet is 58 of 256 byte values,
+  so the odds are about 2e-21), so *every* FlatBuffers UPDATE carrying a
+  related update, and every PUT carrying a related contract, panicked the
+  client's connection task. The PUT case stayed hidden because the loop body
+  only runs on a non-empty vector and the TypeScript suite's fixture passes an
+  empty one.
+
+- **Four more length-unchecked `(required)` fields no longer panic.**
+  `DelegateKey.key`, `SecretsId.hash`, `RegisterDelegate.cipher` and
+  `RegisterDelegate.nonce` were read with `copy_from_slice` or
+  `try_from(..).unwrap()` into fixed-size arrays. The flatbuffers verifier
+  checks that a `(required)` vector is PRESENT, not that it is the right
+  LENGTH, so any client could send a short one and take down its connection
+  task. `DelegateKey` is on the normal delegate path, and the TypeScript SDK
+  exports it as the raw generated type with no length validation.
+
+- **Four union discriminants no longer hit `unreachable!()`.** `ContractType`,
+  `DelegateType`, `UpdateDataType` and `InboundDelegateMsgType` are decoded
+  with `unreachable!()` on an unrecognized discriminant, but every generated
+  union verifier ends in `_ => Ok(())`, so an unknown discriminant — including
+  `NONE` — reaches the decoder. `NONE` is not hypothetical: the TypeScript
+  SDK's `ContractContainer` and `DelegateContainer` constructors both take it
+  as their default argument. All four now return a per-request error, matching
+  what `ContractRequestType` and `DelegateRequestType` already did.
+
+  A single test now sweeps all 256 discriminants of all seven unions on the
+  decode path, so the next union added to the schema is covered without anyone
+  remembering to write a test for it.
+
+  All of the above are **FlatBuffers-only**. The native (bincode) path decodes
+  the same Rust enums directly and never reaches `try_decode_fbs`, and
+  first-party tooling uses `encodingProtocol=native` — which is why this class
+  went unnoticed and why it lands on third-party and browser clients.
+
+### Deprecated
+- **`ContractInstanceId::from_bytes` is renamed to
+  `ContractInstanceId::from_base58`.** It parses base58 *text*, not raw bytes;
+  the old name and its "build from the binary representation" doc are what
+  caused the four decode sites above to feed it raw wire bytes. `from_bytes`
+  remains as a delegating alias, so the rename is not a breaking change, but it
+  now warns. Use `ContractInstanceId::new` for raw bytes you already hold.
+
 - **`ContractKey::try_decode_fbs` no longer double-hashes the code hash.** The
   wire `code` field carries the already-computed 32-byte code hash, but the
   decoder passed it to `CodeHash::from_code`: the *hashing* constructor -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
   only runs on a non-empty vector and the TypeScript suite's fixture passes an
   empty one.
 
+  Stated plainly, because it is not purely a panic fix: those four fields are
+  now **raw-bytes-only**. The old decoder did accept base58 *text* there (that
+  is the one input base58 decoding handles), so a client that worked around the
+  panic by sending text at exactly those fields is rejected now. Raw bytes is
+  what the schema type carries everywhere else, including `ContractKey.instance`
+  in the same request.
+
 - **Four more length-unchecked `(required)` fields no longer panic.**
   `DelegateKey.key`, `SecretsId.hash`, `RegisterDelegate.cipher` and
   `RegisterDelegate.nonce` were read with `copy_from_slice` or
@@ -26,30 +33,29 @@
   exports it as the raw generated type with no length validation.
 
 - **Four union discriminants no longer hit `unreachable!()`.** `ContractType`,
-  `DelegateType`, `UpdateDataType` and `InboundDelegateMsgType` are decoded
+  `DelegateType`, `UpdateDataType` and `InboundDelegateMsgType` were decoded
   with `unreachable!()` on an unrecognized discriminant, but every generated
-  union verifier ends in `_ => Ok(())`, so an unknown discriminant — including
-  `NONE` — reaches the decoder. `NONE` is not hypothetical: the TypeScript
-  SDK's `ContractContainer` and `DelegateContainer` constructors both take it
-  as their default argument. All four now return a per-request error, matching
-  what `ContractRequestType` and `DelegateRequestType` already did.
+  union verifier ends in `_ => Ok(())`, so any discriminant a client sets
+  reaches the decoder's match. All four now return a per-request error,
+  matching what `ContractRequestType` and `DelegateRequestType` already did;
+  those two, plus `ClientRequestType`, now share the same error shape and all
+  report the offending value.
 
-  A single test now sweeps all 256 discriminants of all seven unions on the
-  decode path, so the next union added to the schema is covered without anyone
-  remembering to write a test for it.
+  A single test sweeps all 256 discriminants of all seven unions currently on
+  the decode path, and a source-scrape test fails CI if a new decoder
+  reintroduces either shape.
 
-  All of the above are **FlatBuffers-only**. The native (bincode) path decodes
-  the same Rust enums directly and never reaches `try_decode_fbs`, and
-  first-party tooling uses `encodingProtocol=native` — which is why this class
-  went unnoticed and why it lands on third-party and browser clients.
+- **`HostResponse`'s three related-update variants now encode `related_to` as
+  raw bytes.** They wrote `related_to.encode()` - base58 *text* - into
+  `common.ContractInstanceId.data`, which every other producer and every
+  consumer treats as 32 raw bytes. This is the encode half of the same bug, and
+  it survived because Rust only encodes host responses while only TypeScript
+  decodes them, so no round-trip test ever crossed it.
 
-### Deprecated
-- **`ContractInstanceId::from_bytes` is renamed to
-  `ContractInstanceId::from_base58`.** It parses base58 *text*, not raw bytes;
-  the old name and its "build from the binary representation" doc are what
-  caused the four decode sites above to feed it raw wire bytes. `from_bytes`
-  remains as a delegating alias, so the rename is not a breaking change, but it
-  now warns. Use `ContractInstanceId::new` for raw bytes you already hold.
+Every item above is **FlatBuffers-only**. The native (bincode) path decodes the
+same Rust enums directly and never reaches `try_decode_fbs`, and first-party
+tooling uses `encodingProtocol=native` — which is why this class went unnoticed
+and why it lands on third-party and browser clients.
 
 - **`ContractKey::try_decode_fbs` no longer double-hashes the code hash.** The
   wire `code` field carries the already-computed 32-byte code hash, but the
@@ -72,11 +78,17 @@
   client's connection task. The `ContractKey.instance` field is now
   length-checked at all three sites that decode it (UPDATE, GET, SUBSCRIBE).
 
-  Note the narrow scope: this covers the `ContractKey` fields only. The same
-  unchecked-`unwrap` class survives elsewhere on the same UPDATE request -
-  `UpdateData`'s `Related*` variants apply base58 decoding to bytes already in
-  final form and then unwrap: so an FBS UPDATE carrying one of those variants
-  still panics. Tracked in freenet-core#4996.
+  That entry covered the `ContractKey` fields only; the rest of the same class
+  elsewhere on the decode path - including `UpdateData`'s `Related*` variants -
+  is fixed by the entries above, closing freenet-core#4996.
+
+### Deprecated
+- **`ContractInstanceId::from_bytes` is renamed to
+  `ContractInstanceId::from_base58`.** It parses base58 *text*, not raw bytes;
+  the old name and its "build from the binary representation" doc are what
+  caused the four decode sites above to feed it raw wire bytes. `from_bytes`
+  remains as a delegating alias, so the rename is not a breaking change, but it
+  now warns. Use `ContractInstanceId::new` for raw bytes you already hold.
 
 ### Compatibility
 - **A `ContractKey` whose `code` field is absent or not exactly 32 bytes is now

--- a/rust/src/client_api.rs
+++ b/rust/src/client_api.rs
@@ -73,11 +73,13 @@ pub(crate) fn fixed_size_field<const N: usize>(
     field: &str,
     data: &[u8],
 ) -> Result<[u8; N], WsApiError> {
+    // The message goes over the wire to the client, so it carries what the
+    // client can act on — the field, the expected length, the observed length —
+    // and nothing else. The reason this check has to exist at all is stdlib's
+    // business and lives in the doc comment above.
     data.try_into().map_err(|_| {
         WsApiError::deserialization(format!(
-            "{field} must be exactly {N} bytes; got {} bytes. The flatbuffers verifier only \
-             checks that this required field is present, not that it is the right length, so a \
-             wrong-length value reaches the decoder and must be rejected here.",
+            "{field} must be exactly {N} bytes; got {} bytes",
             data.len()
         ))
     })
@@ -86,16 +88,23 @@ pub(crate) fn fixed_size_field<const N: usize>(
 /// Error text for an unknown flatbuffers union discriminant.
 ///
 /// Every generated union verifier ends in `_ => Ok(())`, so a discriminant the
-/// schema does not define — including `NONE` (0), which several TypeScript SDK
-/// constructors take as their default argument — passes verification and
-/// reaches the decoder's match. Matching such a value with `unreachable!()`
-/// turns one crafted (or merely mistaken) request into a panic that downs the
-/// connection handler, so every union match returns this instead.
+/// schema does not define passes verification and reaches the decoder's match.
+/// Matching such a value with `unreachable!()` turns one crafted request into a
+/// panic that downs the connection handler, so every union match returns this
+/// instead.
+///
+/// Be precise about which values actually get here, because the obvious guess
+/// is wrong. A `NONE` (0) discriminant does NOT reach the decoder: both the
+/// Rust and TypeScript builders elide a field equal to its default
+/// (`FlatBufferBuilder::push_slot`), so `NONE` is written as ABSENT, and
+/// `Verifier::visit_union` rejects the resulting present-value/absent-type pair
+/// as an inconsistent union before any decoder runs. What reaches here is an
+/// out-of-range discriminant, or a `NONE` written explicitly by an encoder that
+/// forces defaults or is not flatc-generated. That is enough — it is still
+/// wire-reachable — but "the TypeScript SDK defaults to NONE" is not the
+/// mechanism, and a test that only checks NONE pins nothing.
 pub(crate) fn unknown_union_discriminant(union: &str, discriminant: u8) -> WsApiError {
-    WsApiError::deserialization(format!(
-        "unknown {union} discriminant: {discriminant}. The flatbuffers verifier accepts any \
-         discriminant it does not recognize, so this is a client error, not an impossible state."
-    ))
+    WsApiError::deserialization(format!("unknown {union} discriminant: {discriminant}"))
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -137,5 +146,101 @@ impl WsApiError {
         );
         finish_host_response_buffer(&mut builder, res);
         builder.finished_data().to_vec()
+    }
+}
+
+/// Source-scrape pins for the decode-boundary conventions.
+///
+/// The conventions this file establishes — every fixed-size wire field goes
+/// through [`fixed_size_field`], every union match ends in
+/// [`unknown_union_discriminant`] — are worth nothing if the next decoder added
+/// to the crate ignores them. Behavioural tests cannot catch that: they only
+/// cover decoders that exist. These scrape the source of every file hosting a
+/// `TryFromFbs` impl, so a new decoder that reintroduces either shape fails CI
+/// even though nobody wrote a test for it.
+///
+/// This is what makes "covered by construction" true rather than aspirational.
+#[cfg(test)]
+mod decode_boundary_conventions {
+    /// Every file with a `TryFromFbs` impl. Add new ones here.
+    const DECODER_SOURCES: [(&str, &str); 5] = [
+        (
+            "client_api/client_events.rs",
+            include_str!("client_api/client_events.rs"),
+        ),
+        (
+            "contract_interface/update.rs",
+            include_str!("contract_interface/update.rs"),
+        ),
+        (
+            "contract_interface/key.rs",
+            include_str!("contract_interface/key.rs"),
+        ),
+        (
+            "delegate_interface.rs",
+            include_str!("delegate_interface.rs"),
+        ),
+        ("versioning.rs", include_str!("versioning.rs")),
+    ];
+
+    /// Lines of real code, with `//` comments dropped — the prose in this crate
+    /// discusses `unreachable!()` at length and must not trip the scan.
+    fn code_lines(src: &str) -> impl Iterator<Item = (usize, &str)> {
+        src.lines()
+            .enumerate()
+            .map(|(i, l)| (i + 1, l.split("//").next().unwrap_or("")))
+            .filter(|(_, l)| !l.trim().is_empty())
+    }
+
+    /// No wire field may be read with a conversion that panics on the wrong
+    /// length. `.bytes()` is the flatbuffers accessor for a wire vector, so a
+    /// line combining it with `unwrap` or `copy_from_slice` is the shape that
+    /// produced four of this change's nine bugs.
+    ///
+    /// The needle is split so this test cannot match its own source if these
+    /// files are ever scraped by a future pin.
+    #[test]
+    fn no_wire_field_is_read_with_a_panicking_conversion() {
+        let wire = concat!(".by", "tes()");
+        let bad = [concat!("unwr", "ap()"), concat!("copy_from_", "slice")];
+        let mut hits = vec![];
+        for (name, src) in DECODER_SOURCES {
+            for (line_no, line) in code_lines(src) {
+                if line.contains(wire) && bad.iter().any(|b| line.contains(b)) {
+                    hits.push(format!("{name}:{line_no}: {}", line.trim()));
+                }
+            }
+        }
+        assert!(
+            hits.is_empty(),
+            "a wire field is read with a conversion that panics on the wrong length. \
+             The flatbuffers verifier checks that a `(required)` field is PRESENT, not \
+             that it is the right LENGTH, so this is reachable from any client and kills \
+             the connection task. Use `client_api::fixed_size_field` instead.\n{}",
+            hits.join("\n")
+        );
+    }
+
+    /// No union match may treat an unrecognized discriminant as impossible.
+    /// Every generated union verifier ends in `_ => Ok(())`, so it is not.
+    #[test]
+    fn union_matches_never_use_unreachable() {
+        let needle = concat!("unreach", "able!");
+        let mut hits = vec![];
+        for (name, src) in DECODER_SOURCES {
+            for (line_no, line) in code_lines(src) {
+                if line.contains(needle) {
+                    hits.push(format!("{name}:{line_no}: {}", line.trim()));
+                }
+            }
+        }
+        assert!(
+            hits.is_empty(),
+            "a decoder treats an unrecognized value as impossible. Every generated \
+             flatbuffers union verifier ends in `_ => Ok(())`, so any discriminant a \
+             client sets reaches the match and this panics the connection task. Return \
+             `client_api::unknown_union_discriminant` instead.\n{}",
+            hits.join("\n")
+        );
     }
 }

--- a/rust/src/client_api.rs
+++ b/rust/src/client_api.rs
@@ -53,6 +53,51 @@ pub trait TryFromFbs<T>: Sized {
     fn try_decode_fbs(value: T) -> Result<Self, WsApiError>;
 }
 
+/// Read a fixed-size byte field out of a verified flatbuffer, rejecting a wrong
+/// length instead of panicking.
+///
+/// **Every** fixed-size wire field must go through this. The flatbuffers
+/// verifier checks that a `(required)` vector is PRESENT; it does NOT check its
+/// LENGTH (`Verifiable for Vector<T>` runs `verify_vector_range` and nothing
+/// else). So `flatbuffers::root` happily accepts an 8-byte field declared
+/// `(required)`, and any decoder that then assumes 32 bytes — via
+/// `try_into().unwrap()`, `<[u8; N]>::try_from(..).unwrap()`, or
+/// `copy_from_slice` — panics on it. Nothing catches unwind on the decode path
+/// and `panic = "abort"` is not set, so that unwinds and kills the client's
+/// connection task: a remote, wire-reachable panic.
+///
+/// `field` is the schema path of the offending field (e.g.
+/// `"ContractKey.instance"`), so the error names the exact thing the client got
+/// wrong rather than saying "invalid data".
+pub(crate) fn fixed_size_field<const N: usize>(
+    field: &str,
+    data: &[u8],
+) -> Result<[u8; N], WsApiError> {
+    data.try_into().map_err(|_| {
+        WsApiError::deserialization(format!(
+            "{field} must be exactly {N} bytes; got {} bytes. The flatbuffers verifier only \
+             checks that this required field is present, not that it is the right length, so a \
+             wrong-length value reaches the decoder and must be rejected here.",
+            data.len()
+        ))
+    })
+}
+
+/// Error text for an unknown flatbuffers union discriminant.
+///
+/// Every generated union verifier ends in `_ => Ok(())`, so a discriminant the
+/// schema does not define — including `NONE` (0), which several TypeScript SDK
+/// constructors take as their default argument — passes verification and
+/// reaches the decoder's match. Matching such a value with `unreachable!()`
+/// turns one crafted (or merely mistaken) request into a panic that downs the
+/// connection handler, so every union match returns this instead.
+pub(crate) fn unknown_union_discriminant(union: &str, discriminant: u8) -> WsApiError {
+    WsApiError::deserialization(format!(
+        "unknown {union} discriminant: {discriminant}. The flatbuffers verifier accepts any \
+         discriminant it does not recognize, so this is a client error, not an impossible state."
+    ))
+}
+
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum WsApiError {

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -384,9 +384,10 @@ impl ClientRequest<'_> {
                             data: Bytes::from(chunk.data().bytes().to_vec()),
                         }
                     }
-                    _ => {
-                        return Err(WsApiError::deserialization(
-                            "unknown client request type".to_string(),
+                    other => {
+                        return Err(crate::client_api::unknown_union_discriminant(
+                            "ClientRequestType",
+                            other.0,
                         ))
                     }
                 },
@@ -504,7 +505,7 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                     // not the full key (which may not be complete on the client side)
                     let fbs_key = get.key();
                     let key = crate::contract_interface::key::instance_id_from_fbs(
-                        "ContractKey.instance",
+                        "ContractKey.instance.data",
                         fbs_key.instance().data().bytes(),
                     )?;
                     let fetch_contract = get.fetch_contract();
@@ -544,7 +545,7 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                     // Extract just the instance ID for Subscribe
                     let fbs_key = subscribe.key();
                     let key = crate::contract_interface::key::instance_id_from_fbs(
-                        "ContractKey.instance",
+                        "ContractKey.instance.data",
                         fbs_key.instance().data().bytes(),
                     )?;
                     let summary = subscribe
@@ -559,10 +560,10 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                 // instead of panicking the connection handler. (Mirrors the same
                 // fix on `DelegateRequest::try_decode_fbs`.)
                 other => {
-                    return Err(WsApiError::deserialization(format!(
-                        "unknown ContractRequestType discriminant: {}",
-                        other.0
-                    )));
+                    return Err(crate::client_api::unknown_union_discriminant(
+                        "ContractRequestType",
+                        other.0,
+                    ));
                 }
             }
         };
@@ -797,10 +798,10 @@ impl<'a> TryFromFbs<&FbsDelegateRequest<'a>> for DelegateRequest<'a> {
                 // here would let a single crafted request take down the connection
                 // handler, so return a per-request error instead.
                 other => {
-                    return Err(WsApiError::deserialization(format!(
-                        "unknown DelegateRequestType discriminant: {}",
-                        other.0
-                    )));
+                    return Err(crate::client_api::unknown_union_discriminant(
+                        "DelegateRequestType",
+                        other.0,
+                    ));
                 }
             }
         };
@@ -1363,8 +1364,13 @@ impl HostResponse {
                         }
                         RelatedState { related_to, state } => {
                             let state_data = builder.create_vector(&state.into_bytes());
-                            let instance_data =
-                                builder.create_vector(related_to.encode().as_bytes());
+                            // RAW 32 bytes, like every other `common.ContractInstanceId`
+                            // producer. This wrote `related_to.encode()` — base58
+                            // TEXT — into a field the schema and the TypeScript
+                            // SDK both read as raw bytes. It is the encode half of
+                            // the decode bug this change fixes: the same field, the
+                            // same wrong transformation, mirrored.
+                            let instance_data = builder.create_vector(related_to.as_bytes());
 
                             let instance_offset = FbsContractInstanceId::create(
                                 &mut builder,
@@ -1390,8 +1396,13 @@ impl HostResponse {
                             )
                         }
                         RelatedDelta { related_to, delta } => {
-                            let instance_data =
-                                builder.create_vector(related_to.encode().as_bytes());
+                            // RAW 32 bytes, like every other `common.ContractInstanceId`
+                            // producer. This wrote `related_to.encode()` — base58
+                            // TEXT — into a field the schema and the TypeScript
+                            // SDK both read as raw bytes. It is the encode half of
+                            // the decode bug this change fixes: the same field, the
+                            // same wrong transformation, mirrored.
+                            let instance_data = builder.create_vector(related_to.as_bytes());
                             let delta_data = builder.create_vector(&delta.into_bytes());
 
                             let instance_offset = FbsContractInstanceId::create(
@@ -1422,8 +1433,13 @@ impl HostResponse {
                             state,
                             delta,
                         } => {
-                            let instance_data =
-                                builder.create_vector(related_to.encode().as_bytes());
+                            // RAW 32 bytes, like every other `common.ContractInstanceId`
+                            // producer. This wrote `related_to.encode()` — base58
+                            // TEXT — into a field the schema and the TypeScript
+                            // SDK both read as raw bytes. It is the encode half of
+                            // the decode bug this change fixes: the same field, the
+                            // same wrong transformation, mirrored.
+                            let instance_data = builder.create_vector(related_to.as_bytes());
                             let state_data = builder.create_vector(&state.into_bytes());
                             let delta_data = builder.create_vector(&delta.into_bytes());
 
@@ -2859,8 +2875,9 @@ mod fbs_decode_hardening {
     // stays valid.
     // ---------------------------------------------------------------------
 
-    fn client_request_type(d: u8) -> Vec<u8> {
+    fn client_request_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
         let get = FbsGet::create(
             &mut b,
@@ -2889,8 +2906,9 @@ mod fbs_decode_hardening {
         b.finished_data().to_vec()
     }
 
-    fn contract_request_type(d: u8) -> Vec<u8> {
+    fn contract_request_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
         let get = FbsGet::create(
             &mut b,
@@ -2904,8 +2922,9 @@ mod fbs_decode_hardening {
         finish_contract(&mut b, ContractRequestType(d), get.as_union_value())
     }
 
-    fn delegate_request_type(d: u8) -> Vec<u8> {
+    fn delegate_request_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let dk = delegate_key_offset(&mut b, &[7u8; 32], &CODE_HASH);
         let params = b.create_vector(&[1u8, 2, 3]);
         let payload = b.create_vector(&[9u8; 4]);
@@ -2938,8 +2957,9 @@ mod fbs_decode_hardening {
     }
 
     /// A PUT whose `common.ContractContainer` union discriminant is `d`.
-    fn contract_type(d: u8) -> Vec<u8> {
+    fn contract_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let code_data = b.create_vector(&[0u8; 8]);
         let code_hash = b.create_vector(&CODE_HASH);
         let code = FbsContractCode::create(
@@ -2989,8 +3009,9 @@ mod fbs_decode_hardening {
     }
 
     /// A RegisterDelegate whose `DelegateContainer` union discriminant is `d`.
-    fn delegate_type(d: u8) -> Vec<u8> {
+    fn delegate_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let code_data = b.create_vector(&[0u8; 8]);
         let code_hash = b.create_vector(&CODE_HASH);
         let code = FbsDelegateCode::create(
@@ -3035,8 +3056,9 @@ mod fbs_decode_hardening {
     }
 
     /// An UPDATE whose `common.UpdateData` union discriminant is `d`.
-    fn update_data_type(d: u8) -> Vec<u8> {
+    fn update_data_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let state = b.create_vector(&[5u8; 4]);
         let state_update = StateUpdate::create(&mut b, &StateUpdateArgs { state: Some(state) });
         let data = FbsUpdateData::create(
@@ -3058,8 +3080,9 @@ mod fbs_decode_hardening {
     }
 
     /// An ApplicationMessages whose `InboundDelegateMsg` union discriminant is `d`.
-    fn inbound_delegate_msg_type(d: u8) -> Vec<u8> {
+    fn inbound_delegate_msg_type(d: u8, force_defaults: bool) -> Vec<u8> {
         let mut b = Builder::new();
+        b.force_defaults(force_defaults);
         let payload = b.create_vector(&[9u8; 4]);
         let context = b.create_vector(&[0u8; 2]);
         let app = FbsApplicationMessage::create(
@@ -3096,26 +3119,29 @@ mod fbs_decode_hardening {
     }
 
     /// `(union name, builder, the union's real discriminant)`.
-    type UnionCase = (&'static str, fn(u8) -> Vec<u8>, u8);
+    type UnionCase = (&'static str, fn(u8, bool) -> Vec<u8>, u8);
 
     /// **No union discriminant, for any of the seven unions on the decode path,
     /// may panic the decoder.**
     ///
-    /// This is the highest-leverage test in the change: it is one sweep that
-    /// covers every union at once, and it covers the next union somebody adds
-    /// to the schema without anyone remembering to write a test for it. Four of
-    /// the seven were `unreachable!()` before this change and every one of them
-    /// is reachable — the generated verifiers all end in `_ => Ok(())`.
+    /// One sweep covering every union at once. Four of the seven were
+    /// `unreachable!()` before this change, and all four are reachable: the
+    /// generated verifiers end in `_ => Ok(())`, so an unrecognized discriminant
+    /// passes verification and lands in the decoder's match.
     ///
-    /// The assertion for the sweep is that the loop RETURNS: a panic anywhere
-    /// inside fails the test. On top of that, two properties are pinned
-    /// explicitly per union, because they are the ones a regression would break
-    /// first:
+    /// Scope, stated honestly: this covers a new *variant* on an existing union
+    /// for free, but NOT a new *union* — `cases` and its builders are written by
+    /// hand. `union_matches_never_use_unreachable` is the guard for that case.
     ///
-    /// - `NONE` (0) is an error, not a panic. NONE is not a hypothetical: the
-    ///   TypeScript SDK's `ContractContainer` and `DelegateContainer`
-    ///   constructors both take it as their DEFAULT argument.
-    /// - An out-of-range discriminant is an error, not a panic.
+    /// Four properties are pinned per union, and the third is the one that keeps
+    /// the other three honest:
+    ///
+    /// - The 0..=255 sweep RETURNS. A panic anywhere inside fails the test.
+    /// - An out-of-range discriminant is a clean error.
+    /// - That error came from the DECODER, not the verifier. Without this the
+    ///   sweep silently degrades to zero decoder coverage the moment a schema or
+    ///   builder change makes verification fail earlier — which is exactly what
+    ///   had happened to the NONE case below.
     /// - The real discriminant still decodes, so the guard did not break the
     ///   happy path.
     #[test]
@@ -3139,23 +3165,45 @@ mod fbs_decode_hardening {
                 // Must return, never panic. A mismatched-but-known discriminant
                 // may be rejected by the verifier rather than the decoder;
                 // either is a clean error and both are acceptable here.
-                let bytes = build(d);
+                let bytes = build(d, false);
                 let _ = ClientRequest::try_decode_fbs(&bytes);
             }
 
-            let none = build(0);
-            assert!(
-                ClientRequest::try_decode_fbs(&none).is_err(),
-                "{union}: a NONE discriminant must be a clean error"
+            // An out-of-range discriminant must be rejected BY THE DECODER.
+            // Asserting only `is_err()` would also pass on a verifier
+            // rejection, which reaches none of the code this change touches.
+            let out_of_range = build(200, false);
+            let err = ClientRequest::try_decode_fbs(&out_of_range)
+                .expect_err("{union}: an out-of-range discriminant must be a clean error");
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "Failed decoding message from client request: unknown {union} \
+                     discriminant: 200"
+                ),
+                "{union}: the error must come from the decoder's union arm, not \
+                 from the verifier — otherwise this sweep pins nothing"
             );
 
-            let out_of_range = build(200);
-            assert!(
-                ClientRequest::try_decode_fbs(&out_of_range).is_err(),
-                "{union}: an out-of-range discriminant must be a clean error"
+            // `NONE` needs `force_defaults`: both builders elide a field equal
+            // to its default, so an ordinary `NONE` is written as ABSENT and
+            // `visit_union` rejects the present-value/absent-type pair before
+            // any decoder runs. Forcing defaults writes the zero explicitly,
+            // which is the shape a non-flatc encoder can put on the wire and
+            // the only one that actually reaches the match arm.
+            let none = build(0, true);
+            let err = ClientRequest::try_decode_fbs(&none)
+                .expect_err("{union}: a NONE discriminant must be a clean error");
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "Failed decoding message from client request: unknown {union} \
+                     discriminant: 0"
+                ),
+                "{union}: an explicit NONE must reach the decoder's union arm"
             );
 
-            let good = build(valid);
+            let good = build(valid, false);
             assert!(
                 ClientRequest::try_decode_fbs(&good).is_ok(),
                 "{union}: the real discriminant must still decode; the guard \
@@ -3269,16 +3317,34 @@ mod fbs_decode_hardening {
 
     /// A wrong-length `related_to` is a clean error naming the field, not a
     /// panic and not a silently truncated id.
+    ///
+    /// Parameterized over all three variants: with one case, copy-pasting the
+    /// wrong variant's field name into the other two arms would fail nothing.
     #[test]
     fn related_to_wrong_length_is_rejected() {
-        let bytes = update_with_related(UpdateDataType::RelatedStateUpdate, &[1u8; 8]);
-        let err = ClientRequest::try_decode_fbs(&bytes)
-            .expect_err("an 8-byte related_to must be rejected");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("RelatedStateUpdate.related_to") && msg.contains("got 8 bytes"),
-            "the error must name the field and the observed length, got: {msg}"
-        );
+        for (variant, field) in [
+            (
+                UpdateDataType::RelatedStateUpdate,
+                "RelatedStateUpdate.related_to.data",
+            ),
+            (
+                UpdateDataType::RelatedDeltaUpdate,
+                "RelatedDeltaUpdate.related_to.data",
+            ),
+            (
+                UpdateDataType::RelatedStateAndDeltaUpdate,
+                "RelatedStateAndDeltaUpdate.related_to.data",
+            ),
+        ] {
+            let bytes = update_with_related(variant, &[1u8; 8]);
+            let err = ClientRequest::try_decode_fbs(&bytes)
+                .expect_err("an 8-byte related_to must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(field) && msg.contains("got 8 bytes"),
+                "the error must name {field} and the observed length, got: {msg}"
+            );
+        }
     }
 
     fn put_with_related_contract(id: &[u8]) -> Vec<u8> {
@@ -3487,6 +3553,61 @@ mod fbs_decode_hardening {
         assert!(
             ClientRequest::try_decode_fbs(&register_delegate(32, 24)).is_ok(),
             "correct cipher/nonce lengths must still decode"
+        );
+    }
+
+    /// The ENCODE half of the same bug: `HostResponse`'s three related-update
+    /// variants wrote `related_to.encode()` — base58 TEXT — into
+    /// `common.ContractInstanceId.data`, a field every other producer and every
+    /// consumer treats as 32 raw bytes.
+    ///
+    /// It survived because Rust only encodes host responses and only TypeScript
+    /// decodes them, so no Rust round-trip test ever crossed it, and the
+    /// TypeScript SDK has no test that reads `relatedTo` back out of a
+    /// notification. Pinned here by decoding the encoder's own output, which is
+    /// the cheapest thing that would have caught it.
+    #[test]
+    fn host_response_encodes_related_to_as_raw_bytes() {
+        use crate::client_api::{ContractResponse, HostResponse};
+        use crate::contract_interface::{ContractInstanceId, ContractKey, State};
+        use crate::generated::host_response::{root_as_host_response, ContractResponseType};
+
+        let related = ContractInstanceId::new(INSTANCE);
+        let key = ContractKey::from_params_and_code(
+            crate::parameters::Parameters::from(vec![1u8, 2]),
+            crate::contract_interface::ContractCode::from(vec![0u8; 8]),
+        );
+        let response = HostResponse::ContractResponse(ContractResponse::UpdateNotification {
+            key,
+            update: UpdateData::RelatedState {
+                related_to: related,
+                state: State::from(vec![9u8; 4]),
+            },
+        });
+
+        let bytes = response.into_fbs_bytes().expect("encoding must succeed");
+        let host = root_as_host_response(&bytes).expect("the encoder must emit a valid buffer");
+        let contract = host
+            .response_as_contract_response()
+            .expect("a ContractResponse");
+        assert_eq!(
+            contract.contract_response_type(),
+            ContractResponseType::UpdateNotification
+        );
+        let notification = contract
+            .contract_response_as_update_notification()
+            .expect("an UpdateNotification");
+        let related_update = notification
+            .update()
+            .update_data_as_related_state_update()
+            .expect("a RelatedStateUpdate");
+
+        assert_eq!(
+            related_update.related_to().data().bytes(),
+            &INSTANCE,
+            "related_to must be the 32 RAW id bytes. Encoding it as base58 text \
+             puts ~44 ASCII bytes in a field the TypeScript SDK reads as a raw \
+             Uint8Array, and that our own decoder now rejects."
         );
     }
 

--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -504,6 +504,7 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                     // not the full key (which may not be complete on the client side)
                     let fbs_key = get.key();
                     let key = crate::contract_interface::key::instance_id_from_fbs(
+                        "ContractKey.instance",
                         fbs_key.instance().data().bytes(),
                     )?;
                     let fetch_contract = get.fetch_contract();
@@ -543,6 +544,7 @@ impl<'a> TryFromFbs<&FbsContractRequest<'a>> for ContractRequest<'a> {
                     // Extract just the instance ID for Subscribe
                     let fbs_key = subscribe.key();
                     let key = crate::contract_interface::key::instance_id_from_fbs(
+                        "ContractKey.instance",
                         fbs_key.instance().data().bytes(),
                     )?;
                     let summary = subscribe
@@ -763,11 +765,20 @@ impl<'a> TryFromFbs<&FbsDelegateRequest<'a>> for DelegateRequest<'a> {
                 DelegateRequestType::RegisterDelegate => {
                     let register = request.delegate_request_as_register_delegate().unwrap();
                     let delegate = DelegateContainer::try_decode_fbs(&register.delegate())?;
-                    let cipher =
-                        <[u8; 32]>::try_from(register.cipher().bytes().to_vec().as_slice())
-                            .unwrap();
-                    let nonce =
-                        <[u8; 24]>::try_from(register.nonce().bytes().to_vec().as_slice()).unwrap();
+                    // `cipher` and `nonce` are `(required)`, which the verifier
+                    // reads as "present", not "32 and 24 bytes". The
+                    // `try_from(..).unwrap()` this replaces panicked on any
+                    // other length, killing the connection task. (The
+                    // intermediate `.to_vec()` went with it: `bytes()` is
+                    // already a slice.)
+                    let cipher = crate::client_api::fixed_size_field::<32>(
+                        "RegisterDelegate.cipher",
+                        register.cipher().bytes(),
+                    )?;
+                    let nonce = crate::client_api::fixed_size_field::<24>(
+                        "RegisterDelegate.nonce",
+                        register.nonce().bytes(),
+                    )?;
                     DelegateRequest::RegisterDelegate {
                         delegate,
                         cipher,
@@ -2694,6 +2705,828 @@ mod delegate_request_wire_format {
             decoded.is_err(),
             "an unknown DelegateRequestType discriminant must be a clean \
              per-request error, never a panic that downs the connection handler"
+        );
+    }
+}
+
+/// Hardening pins for the flatbuffers decode boundary.
+///
+/// Every test here exists because a real decode site panicked, or silently
+/// produced a wrong value, on input a client can actually send. The boundary
+/// has exactly one entry point — [`ClientRequest::try_decode_fbs`] over
+/// `root_as_client_request` — so these drive the real entry point rather than
+/// an inner decoder wherever possible.
+///
+/// Two facts about the flatbuffers verifier make this whole class possible, and
+/// both are load-bearing for every test below:
+///
+/// 1. A `(required)` vector is checked for PRESENCE, not LENGTH
+///    (`Verifiable for Vector<T>` runs `verify_vector_range` and stops there).
+/// 2. Every generated union verifier ends in `_ => Ok(())`, so an unknown
+///    discriminant — including `NONE` — reaches the decoder's match.
+#[cfg(test)]
+mod fbs_decode_hardening {
+    use super::{ClientRequest, ContractRequest};
+    use crate::client_api::TryFromFbs;
+    use crate::contract_interface::UpdateData;
+    use crate::generated::client_request::{
+        finish_client_request_buffer, ApplicationMessages, ApplicationMessagesArgs,
+        ClientRequest as FbsClientRequest, ClientRequestArgs, ClientRequestType,
+        ContractRequest as FbsContractRequest, ContractRequestArgs, ContractRequestType,
+        DelegateCode as FbsDelegateCode, DelegateCodeArgs,
+        DelegateContainer as FbsDelegateContainer, DelegateContainerArgs,
+        DelegateKey as FbsDelegateKey, DelegateKeyArgs, DelegateRequest as FbsDelegateRequest,
+        DelegateRequestArgs, DelegateRequestType, DelegateType, Get as FbsGet, GetArgs,
+        InboundDelegateMsg as FbsInboundDelegateMsg, InboundDelegateMsgArgs,
+        InboundDelegateMsgType, Put as FbsPut, PutArgs, RegisterDelegate, RegisterDelegateArgs,
+        RelatedContract, RelatedContractArgs, RelatedContracts as FbsRelatedContracts,
+        RelatedContractsArgs, Update as FbsUpdate, UpdateArgs, WasmDelegateV1, WasmDelegateV1Args,
+    };
+    use crate::generated::common::{
+        ApplicationMessage as FbsApplicationMessage, ApplicationMessageArgs,
+        ContractCode as FbsContractCode, ContractCodeArgs,
+        ContractContainer as FbsContractContainer, ContractContainerArgs,
+        ContractInstanceId as FbsContractInstanceId, ContractInstanceIdArgs,
+        ContractKey as FbsContractKey, ContractKeyArgs, ContractType, RelatedDeltaUpdate,
+        RelatedDeltaUpdateArgs, RelatedStateAndDeltaUpdate, RelatedStateAndDeltaUpdateArgs,
+        RelatedStateUpdate, RelatedStateUpdateArgs, StateUpdate, StateUpdateArgs,
+        UpdateData as FbsUpdateData, UpdateDataArgs, UpdateDataType, WasmContractV1,
+        WasmContractV1Args,
+    };
+
+    type Builder<'a> = flatbuffers::FlatBufferBuilder<'a>;
+
+    /// The instance id the tests round-trip. Deliberately NOT all-ASCII: this is
+    /// what a real 32-byte id looks like, and it is precisely what the old
+    /// base58 decode choked on.
+    const INSTANCE: [u8; 32] = [
+        0x00, 0xff, 0x7a, 0x01, 0x30, 0x4f, 0x49, 0x6c, 0x2b, 0x2f, 0x5c, 0x7f, 0x80, 0xfe, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+        0x20, 0x21,
+    ];
+    const CODE_HASH: [u8; 32] = [42u8; 32];
+
+    fn instance_offset<'a>(
+        b: &mut Builder<'a>,
+        bytes: &[u8],
+    ) -> flatbuffers::WIPOffset<FbsContractInstanceId<'a>> {
+        let data = b.create_vector(bytes);
+        FbsContractInstanceId::create(b, &ContractInstanceIdArgs { data: Some(data) })
+    }
+
+    fn key_offset<'a>(
+        b: &mut Builder<'a>,
+        instance: &[u8],
+        code: &[u8],
+    ) -> flatbuffers::WIPOffset<FbsContractKey<'a>> {
+        let instance = instance_offset(b, instance);
+        let code = b.create_vector(code);
+        FbsContractKey::create(
+            b,
+            &ContractKeyArgs {
+                instance: Some(instance),
+                code: Some(code),
+            },
+        )
+    }
+
+    fn delegate_key_offset<'a>(
+        b: &mut Builder<'a>,
+        key: &[u8],
+        code_hash: &[u8],
+    ) -> flatbuffers::WIPOffset<FbsDelegateKey<'a>> {
+        let key = b.create_vector(key);
+        let code_hash = b.create_vector(code_hash);
+        FbsDelegateKey::create(
+            b,
+            &DelegateKeyArgs {
+                key: Some(key),
+                code_hash: Some(code_hash),
+            },
+        )
+    }
+
+    /// Finish a `ContractRequest`-carrying `ClientRequest` and return its bytes.
+    fn finish_contract(
+        b: &mut Builder<'_>,
+        ty: ContractRequestType,
+        req: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>,
+    ) -> Vec<u8> {
+        let contract = FbsContractRequest::create(
+            b,
+            &ContractRequestArgs {
+                contract_request_type: ty,
+                contract_request: Some(req),
+            },
+        );
+        let client = FbsClientRequest::create(
+            b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType::ContractRequest,
+                client_request: Some(contract.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(b, client);
+        b.finished_data().to_vec()
+    }
+
+    fn finish_delegate(
+        b: &mut Builder<'_>,
+        ty: DelegateRequestType,
+        req: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>,
+    ) -> Vec<u8> {
+        let delegate = FbsDelegateRequest::create(
+            b,
+            &DelegateRequestArgs {
+                delegate_request_type: ty,
+                delegate_request: Some(req),
+            },
+        );
+        let client = FbsClientRequest::create(
+            b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType::DelegateRequest,
+                client_request: Some(delegate.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(b, client);
+        b.finished_data().to_vec()
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-union builders. Each produces a well-formed request whose ONE named
+    // union discriminant is `d`, so a test can sweep `d` while everything else
+    // stays valid.
+    // ---------------------------------------------------------------------
+
+    fn client_request_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
+        let get = FbsGet::create(
+            &mut b,
+            &GetArgs {
+                key: Some(key),
+                fetch_contract: false,
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+        );
+        let contract = FbsContractRequest::create(
+            &mut b,
+            &ContractRequestArgs {
+                contract_request_type: ContractRequestType::Get,
+                contract_request: Some(get.as_union_value()),
+            },
+        );
+        let client = FbsClientRequest::create(
+            &mut b,
+            &ClientRequestArgs {
+                client_request_type: ClientRequestType(d),
+                client_request: Some(contract.as_union_value()),
+            },
+        );
+        finish_client_request_buffer(&mut b, client);
+        b.finished_data().to_vec()
+    }
+
+    fn contract_request_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
+        let get = FbsGet::create(
+            &mut b,
+            &GetArgs {
+                key: Some(key),
+                fetch_contract: false,
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+        );
+        finish_contract(&mut b, ContractRequestType(d), get.as_union_value())
+    }
+
+    fn delegate_request_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let dk = delegate_key_offset(&mut b, &[7u8; 32], &CODE_HASH);
+        let params = b.create_vector(&[1u8, 2, 3]);
+        let payload = b.create_vector(&[9u8; 4]);
+        let context = b.create_vector(&[0u8; 2]);
+        let app = FbsApplicationMessage::create(
+            &mut b,
+            &ApplicationMessageArgs {
+                payload: Some(payload),
+                context: Some(context),
+                processed: false,
+            },
+        );
+        let inbound_msg = FbsInboundDelegateMsg::create(
+            &mut b,
+            &InboundDelegateMsgArgs {
+                inbound_type: InboundDelegateMsgType::common_ApplicationMessage,
+                inbound: Some(app.as_union_value()),
+            },
+        );
+        let inbound = b.create_vector(&[inbound_msg]);
+        let msgs = ApplicationMessages::create(
+            &mut b,
+            &ApplicationMessagesArgs {
+                key: Some(dk),
+                params: Some(params),
+                inbound: Some(inbound),
+            },
+        );
+        finish_delegate(&mut b, DelegateRequestType(d), msgs.as_union_value())
+    }
+
+    /// A PUT whose `common.ContractContainer` union discriminant is `d`.
+    fn contract_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let code_data = b.create_vector(&[0u8; 8]);
+        let code_hash = b.create_vector(&CODE_HASH);
+        let code = FbsContractCode::create(
+            &mut b,
+            &ContractCodeArgs {
+                data: Some(code_data),
+                code_hash: Some(code_hash),
+            },
+        );
+        let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
+        let params = b.create_vector(&[1u8, 2]);
+        let wasm = WasmContractV1::create(
+            &mut b,
+            &WasmContractV1Args {
+                data: Some(code),
+                parameters: Some(params),
+                key: Some(key),
+            },
+        );
+        let container = FbsContractContainer::create(
+            &mut b,
+            &ContractContainerArgs {
+                contract_type: ContractType(d),
+                contract: Some(wasm.as_union_value()),
+            },
+        );
+        let state = b.create_vector(&[3u8; 4]);
+        let empty: Vec<flatbuffers::WIPOffset<RelatedContract>> = vec![];
+        let contracts = b.create_vector(&empty);
+        let related = FbsRelatedContracts::create(
+            &mut b,
+            &RelatedContractsArgs {
+                contracts: Some(contracts),
+            },
+        );
+        let put = FbsPut::create(
+            &mut b,
+            &PutArgs {
+                container: Some(container),
+                wrapped_state: Some(state),
+                related_contracts: Some(related),
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+        );
+        finish_contract(&mut b, ContractRequestType::Put, put.as_union_value())
+    }
+
+    /// A RegisterDelegate whose `DelegateContainer` union discriminant is `d`.
+    fn delegate_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let code_data = b.create_vector(&[0u8; 8]);
+        let code_hash = b.create_vector(&CODE_HASH);
+        let code = FbsDelegateCode::create(
+            &mut b,
+            &DelegateCodeArgs {
+                data: Some(code_data),
+                code_hash: Some(code_hash),
+            },
+        );
+        let dk = delegate_key_offset(&mut b, &[7u8; 32], &CODE_HASH);
+        let params = b.create_vector(&[1u8, 2]);
+        let wasm = WasmDelegateV1::create(
+            &mut b,
+            &WasmDelegateV1Args {
+                parameters: Some(params),
+                data: Some(code),
+                key: Some(dk),
+            },
+        );
+        let container = FbsDelegateContainer::create(
+            &mut b,
+            &DelegateContainerArgs {
+                delegate_type: DelegateType(d),
+                delegate: Some(wasm.as_union_value()),
+            },
+        );
+        let cipher = b.create_vector(&[1u8; 32]);
+        let nonce = b.create_vector(&[2u8; 24]);
+        let register = RegisterDelegate::create(
+            &mut b,
+            &RegisterDelegateArgs {
+                delegate: Some(container),
+                cipher: Some(cipher),
+                nonce: Some(nonce),
+            },
+        );
+        finish_delegate(
+            &mut b,
+            DelegateRequestType::RegisterDelegate,
+            register.as_union_value(),
+        )
+    }
+
+    /// An UPDATE whose `common.UpdateData` union discriminant is `d`.
+    fn update_data_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let state = b.create_vector(&[5u8; 4]);
+        let state_update = StateUpdate::create(&mut b, &StateUpdateArgs { state: Some(state) });
+        let data = FbsUpdateData::create(
+            &mut b,
+            &UpdateDataArgs {
+                update_data_type: UpdateDataType(d),
+                update_data: Some(state_update.as_union_value()),
+            },
+        );
+        let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
+        let update = FbsUpdate::create(
+            &mut b,
+            &UpdateArgs {
+                key: Some(key),
+                data: Some(data),
+            },
+        );
+        finish_contract(&mut b, ContractRequestType::Update, update.as_union_value())
+    }
+
+    /// An ApplicationMessages whose `InboundDelegateMsg` union discriminant is `d`.
+    fn inbound_delegate_msg_type(d: u8) -> Vec<u8> {
+        let mut b = Builder::new();
+        let payload = b.create_vector(&[9u8; 4]);
+        let context = b.create_vector(&[0u8; 2]);
+        let app = FbsApplicationMessage::create(
+            &mut b,
+            &ApplicationMessageArgs {
+                payload: Some(payload),
+                context: Some(context),
+                processed: false,
+            },
+        );
+        let inbound_msg = FbsInboundDelegateMsg::create(
+            &mut b,
+            &InboundDelegateMsgArgs {
+                inbound_type: InboundDelegateMsgType(d),
+                inbound: Some(app.as_union_value()),
+            },
+        );
+        let inbound = b.create_vector(&[inbound_msg]);
+        let dk = delegate_key_offset(&mut b, &[7u8; 32], &CODE_HASH);
+        let params = b.create_vector(&[1u8, 2, 3]);
+        let msgs = ApplicationMessages::create(
+            &mut b,
+            &ApplicationMessagesArgs {
+                key: Some(dk),
+                params: Some(params),
+                inbound: Some(inbound),
+            },
+        );
+        finish_delegate(
+            &mut b,
+            DelegateRequestType::ApplicationMessages,
+            msgs.as_union_value(),
+        )
+    }
+
+    /// `(union name, builder, the union's real discriminant)`.
+    type UnionCase = (&'static str, fn(u8) -> Vec<u8>, u8);
+
+    /// **No union discriminant, for any of the seven unions on the decode path,
+    /// may panic the decoder.**
+    ///
+    /// This is the highest-leverage test in the change: it is one sweep that
+    /// covers every union at once, and it covers the next union somebody adds
+    /// to the schema without anyone remembering to write a test for it. Four of
+    /// the seven were `unreachable!()` before this change and every one of them
+    /// is reachable — the generated verifiers all end in `_ => Ok(())`.
+    ///
+    /// The assertion for the sweep is that the loop RETURNS: a panic anywhere
+    /// inside fails the test. On top of that, two properties are pinned
+    /// explicitly per union, because they are the ones a regression would break
+    /// first:
+    ///
+    /// - `NONE` (0) is an error, not a panic. NONE is not a hypothetical: the
+    ///   TypeScript SDK's `ContractContainer` and `DelegateContainer`
+    ///   constructors both take it as their DEFAULT argument.
+    /// - An out-of-range discriminant is an error, not a panic.
+    /// - The real discriminant still decodes, so the guard did not break the
+    ///   happy path.
+    #[test]
+    fn no_union_discriminant_panics_the_decoder() {
+        let cases: [UnionCase; 7] = [
+            ("ClientRequestType", client_request_type, 1),
+            ("ContractRequestType", contract_request_type, 3),
+            ("DelegateRequestType", delegate_request_type, 1),
+            ("ContractType", contract_type, 1),
+            ("DelegateType", delegate_type, 1),
+            ("UpdateDataType", update_data_type, 1),
+            (
+                "InboundDelegateMsgType",
+                inbound_delegate_msg_type,
+                InboundDelegateMsgType::common_ApplicationMessage.0,
+            ),
+        ];
+
+        for (union, build, valid) in cases {
+            for d in 0..=u8::MAX {
+                // Must return, never panic. A mismatched-but-known discriminant
+                // may be rejected by the verifier rather than the decoder;
+                // either is a clean error and both are acceptable here.
+                let bytes = build(d);
+                let _ = ClientRequest::try_decode_fbs(&bytes);
+            }
+
+            let none = build(0);
+            assert!(
+                ClientRequest::try_decode_fbs(&none).is_err(),
+                "{union}: a NONE discriminant must be a clean error"
+            );
+
+            let out_of_range = build(200);
+            assert!(
+                ClientRequest::try_decode_fbs(&out_of_range).is_err(),
+                "{union}: an out-of-range discriminant must be a clean error"
+            );
+
+            let good = build(valid);
+            assert!(
+                ClientRequest::try_decode_fbs(&good).is_ok(),
+                "{union}: the real discriminant must still decode; the guard \
+                 must not break the happy path"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-site pins. Each of these fails if its own decode site is reverted,
+    // so a partial revert cannot leave the suite green — the failure mode #85
+    // shipped with, where the fix reached three call sites and only one was
+    // pinned.
+    // ---------------------------------------------------------------------
+
+    /// Build an UPDATE carrying one of the three `related_*` update variants,
+    /// with `id` as the raw `related_to` bytes.
+    fn update_with_related(variant: UpdateDataType, id: &[u8]) -> Vec<u8> {
+        let mut b = Builder::new();
+        let related_to = instance_offset(&mut b, id);
+        let payload = b.create_vector(&[5u8; 4]);
+        let data_offset = match variant {
+            UpdateDataType::RelatedStateUpdate => RelatedStateUpdate::create(
+                &mut b,
+                &RelatedStateUpdateArgs {
+                    related_to: Some(related_to),
+                    state: Some(payload),
+                },
+            )
+            .as_union_value(),
+            UpdateDataType::RelatedDeltaUpdate => RelatedDeltaUpdate::create(
+                &mut b,
+                &RelatedDeltaUpdateArgs {
+                    related_to: Some(related_to),
+                    delta: Some(payload),
+                },
+            )
+            .as_union_value(),
+            UpdateDataType::RelatedStateAndDeltaUpdate => {
+                let delta = b.create_vector(&[6u8; 4]);
+                RelatedStateAndDeltaUpdate::create(
+                    &mut b,
+                    &RelatedStateAndDeltaUpdateArgs {
+                        related_to: Some(related_to),
+                        state: Some(payload),
+                        delta: Some(delta),
+                    },
+                )
+                .as_union_value()
+            }
+            other => panic!("not a related update variant: {}", other.0),
+        };
+        let data = FbsUpdateData::create(
+            &mut b,
+            &UpdateDataArgs {
+                update_data_type: variant,
+                update_data: Some(data_offset),
+            },
+        );
+        let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
+        let update = FbsUpdate::create(
+            &mut b,
+            &UpdateArgs {
+                key: Some(key),
+                data: Some(data),
+            },
+        );
+        finish_contract(&mut b, ContractRequestType::Update, update.as_union_value())
+    }
+
+    fn decoded_related_to(bytes: &[u8]) -> [u8; 32] {
+        let req = ClientRequest::try_decode_fbs(bytes)
+            .expect("a well-formed related update must decode, not panic");
+        let ClientRequest::ContractOp(ContractRequest::Update { data, .. }) = req else {
+            panic!("expected an UPDATE, got {req:?}");
+        };
+        match data {
+            UpdateData::RelatedState { related_to, .. }
+            | UpdateData::RelatedDelta { related_to, .. }
+            | UpdateData::RelatedStateAndDelta { related_to, .. } => *related_to,
+            other => panic!("expected a related update, got {other:?}"),
+        }
+    }
+
+    /// `related_to` is 32 RAW bytes and must round-trip byte-for-byte.
+    ///
+    /// This decode used to be `ContractInstanceId::from_bytes(..).unwrap()` —
+    /// a base58 *string* decoder pointed at bytes that are already the final
+    /// id. It did not merely mishandle malformed input: a random 32-byte id
+    /// essentially never consists solely of base58 characters, so EVERY
+    /// well-formed related update panicked the connection task. `INSTANCE`
+    /// contains `0x00`, `0xff` and the base58-excluded `0`/`O`/`I`/`l`
+    /// characters precisely so a revert cannot pass by luck.
+    #[test]
+    fn related_state_update_round_trips_the_raw_instance_id() {
+        let bytes = update_with_related(UpdateDataType::RelatedStateUpdate, &INSTANCE);
+        assert_eq!(decoded_related_to(&bytes), INSTANCE);
+    }
+
+    #[test]
+    fn related_delta_update_round_trips_the_raw_instance_id() {
+        let bytes = update_with_related(UpdateDataType::RelatedDeltaUpdate, &INSTANCE);
+        assert_eq!(decoded_related_to(&bytes), INSTANCE);
+    }
+
+    #[test]
+    fn related_state_and_delta_update_round_trips_the_raw_instance_id() {
+        let bytes = update_with_related(UpdateDataType::RelatedStateAndDeltaUpdate, &INSTANCE);
+        assert_eq!(decoded_related_to(&bytes), INSTANCE);
+    }
+
+    /// A wrong-length `related_to` is a clean error naming the field, not a
+    /// panic and not a silently truncated id.
+    #[test]
+    fn related_to_wrong_length_is_rejected() {
+        let bytes = update_with_related(UpdateDataType::RelatedStateUpdate, &[1u8; 8]);
+        let err = ClientRequest::try_decode_fbs(&bytes)
+            .expect_err("an 8-byte related_to must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("RelatedStateUpdate.related_to") && msg.contains("got 8 bytes"),
+            "the error must name the field and the observed length, got: {msg}"
+        );
+    }
+
+    fn put_with_related_contract(id: &[u8]) -> Vec<u8> {
+        let mut b = Builder::new();
+        let code_data = b.create_vector(&[0u8; 8]);
+        let code_hash = b.create_vector(&CODE_HASH);
+        let code = FbsContractCode::create(
+            &mut b,
+            &ContractCodeArgs {
+                data: Some(code_data),
+                code_hash: Some(code_hash),
+            },
+        );
+        let key = key_offset(&mut b, &INSTANCE, &CODE_HASH);
+        let params = b.create_vector(&[1u8, 2]);
+        let wasm = WasmContractV1::create(
+            &mut b,
+            &WasmContractV1Args {
+                data: Some(code),
+                parameters: Some(params),
+                key: Some(key),
+            },
+        );
+        let container = FbsContractContainer::create(
+            &mut b,
+            &ContractContainerArgs {
+                contract_type: ContractType::WasmContractV1,
+                contract: Some(wasm.as_union_value()),
+            },
+        );
+        let related_id = instance_offset(&mut b, id);
+        let related_state = b.create_vector(&[8u8; 3]);
+        let related_contract = RelatedContract::create(
+            &mut b,
+            &RelatedContractArgs {
+                instance_id: Some(related_id),
+                state: Some(related_state),
+            },
+        );
+        let contracts = b.create_vector(&[related_contract]);
+        let related = FbsRelatedContracts::create(
+            &mut b,
+            &RelatedContractsArgs {
+                contracts: Some(contracts),
+            },
+        );
+        let state = b.create_vector(&[3u8; 4]);
+        let put = FbsPut::create(
+            &mut b,
+            &PutArgs {
+                container: Some(container),
+                wrapped_state: Some(state),
+                related_contracts: Some(related),
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+        );
+        finish_contract(&mut b, ContractRequestType::Put, put.as_union_value())
+    }
+
+    /// The same base58 bug lived on the PUT path, in `RelatedContracts`. It went
+    /// unnoticed because the loop body only runs when the vector is NON-empty,
+    /// and the TypeScript suite's PUT fixture passes `new RelatedContractsT([])`.
+    #[test]
+    fn put_related_contract_round_trips_the_raw_instance_id() {
+        let bytes = put_with_related_contract(&INSTANCE);
+        let req = ClientRequest::try_decode_fbs(&bytes)
+            .expect("a PUT carrying a related contract must decode, not panic");
+        let ClientRequest::ContractOp(ContractRequest::Put {
+            related_contracts, ..
+        }) = req
+        else {
+            panic!("expected a PUT, got {req:?}");
+        };
+        let ids: Vec<[u8; 32]> = related_contracts
+            .into_owned()
+            .states()
+            .map(|(id, _)| **id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec![INSTANCE],
+            "the related contract id must round-trip"
+        );
+    }
+
+    #[test]
+    fn put_related_contract_wrong_length_id_is_rejected() {
+        let bytes = put_with_related_contract(&[1u8; 8]);
+        let err = ClientRequest::try_decode_fbs(&bytes)
+            .expect_err("an 8-byte related contract id must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("RelatedContract.instance_id") && msg.contains("got 8 bytes"),
+            "got: {msg}"
+        );
+    }
+
+    fn unregister_delegate(key_len: usize) -> Vec<u8> {
+        use crate::generated::client_request::{UnregisterDelegate, UnregisterDelegateArgs};
+        let mut b = Builder::new();
+        let dk = delegate_key_offset(&mut b, &vec![7u8; key_len], &CODE_HASH);
+        let unregister =
+            UnregisterDelegate::create(&mut b, &UnregisterDelegateArgs { key: Some(dk) });
+        finish_delegate(
+            &mut b,
+            DelegateRequestType::UnregisterDelegate,
+            unregister.as_union_value(),
+        )
+    }
+
+    /// `DelegateKey.key` is `(required)` but length-unchecked by the verifier,
+    /// and the decoder used to `copy_from_slice` it into a `[0; 32]` — which
+    /// panics on a mismatch. This is the normal delegate path, and the
+    /// TypeScript SDK exports `DelegateKey` as the raw generated type with no
+    /// length validation (unlike `ContractKey`, which throws a `TypeError`).
+    #[test]
+    fn delegate_key_wrong_length_is_rejected_not_panicking() {
+        let short = unregister_delegate(8);
+        let err = ClientRequest::try_decode_fbs(&short)
+            .expect_err("an 8-byte delegate key must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("DelegateKey.key") && msg.contains("got 8 bytes"),
+            "got: {msg}"
+        );
+
+        let long = unregister_delegate(64);
+        let err = ClientRequest::try_decode_fbs(&long)
+            .expect_err("a 64-byte delegate key must be rejected");
+        assert!(err.to_string().contains("got 64 bytes"), "got: {err}");
+
+        let good = unregister_delegate(32);
+        assert!(
+            ClientRequest::try_decode_fbs(&good).is_ok(),
+            "a 32-byte delegate key must still decode"
+        );
+    }
+
+    fn register_delegate(cipher_len: usize, nonce_len: usize) -> Vec<u8> {
+        let mut b = Builder::new();
+        let code_data = b.create_vector(&[0u8; 8]);
+        let code_hash = b.create_vector(&CODE_HASH);
+        let code = FbsDelegateCode::create(
+            &mut b,
+            &DelegateCodeArgs {
+                data: Some(code_data),
+                code_hash: Some(code_hash),
+            },
+        );
+        let dk = delegate_key_offset(&mut b, &[7u8; 32], &CODE_HASH);
+        let params = b.create_vector(&[1u8, 2]);
+        let wasm = WasmDelegateV1::create(
+            &mut b,
+            &WasmDelegateV1Args {
+                parameters: Some(params),
+                data: Some(code),
+                key: Some(dk),
+            },
+        );
+        let container = FbsDelegateContainer::create(
+            &mut b,
+            &DelegateContainerArgs {
+                delegate_type: DelegateType::WasmDelegateV1,
+                delegate: Some(wasm.as_union_value()),
+            },
+        );
+        let cipher = b.create_vector(&vec![1u8; cipher_len]);
+        let nonce = b.create_vector(&vec![2u8; nonce_len]);
+        let register = RegisterDelegate::create(
+            &mut b,
+            &RegisterDelegateArgs {
+                delegate: Some(container),
+                cipher: Some(cipher),
+                nonce: Some(nonce),
+            },
+        );
+        finish_delegate(
+            &mut b,
+            DelegateRequestType::RegisterDelegate,
+            register.as_union_value(),
+        )
+    }
+
+    /// `cipher` (32) and `nonce` (24) are the same shape: `(required)`, so the
+    /// verifier guarantees presence and nothing about length, and the decoder
+    /// used to `try_from(..).unwrap()` them.
+    #[test]
+    fn register_delegate_wrong_length_cipher_or_nonce_is_rejected() {
+        let err = ClientRequest::try_decode_fbs(&register_delegate(16, 24))
+            .expect_err("a 16-byte cipher must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("RegisterDelegate.cipher") && msg.contains("got 16 bytes"),
+            "got: {msg}"
+        );
+
+        let err = ClientRequest::try_decode_fbs(&register_delegate(32, 8))
+            .expect_err("an 8-byte nonce must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("RegisterDelegate.nonce") && msg.contains("got 8 bytes"),
+            "got: {msg}"
+        );
+
+        assert!(
+            ClientRequest::try_decode_fbs(&register_delegate(32, 24)).is_ok(),
+            "correct cipher/nonce lengths must still decode"
+        );
+    }
+
+    /// `SecretsId::try_decode_fbs` has no production caller today, so it is
+    /// pinned directly rather than through a request. Fixing it now means the
+    /// first client to reach it does not find a panic waiting.
+    #[test]
+    fn secrets_id_wrong_length_hash_is_rejected_not_panicking() {
+        use crate::delegate_interface::SecretsId;
+        use crate::generated::common::{SecretsId as FbsSecretsId, SecretsIdArgs};
+
+        let build = |hash_len: usize| {
+            let mut b = Builder::new();
+            let key = b.create_vector(&[1u8, 2, 3]);
+            let hash = b.create_vector(&vec![4u8; hash_len]);
+            let id = FbsSecretsId::create(
+                &mut b,
+                &SecretsIdArgs {
+                    key: Some(key),
+                    hash: Some(hash),
+                },
+            );
+            b.finish_minimal(id);
+            b.finished_data().to_vec()
+        };
+
+        let bytes = build(8);
+        let fbs = flatbuffers::root::<FbsSecretsId>(&bytes)
+            .expect("the verifier accepts a short required vector");
+        let err = SecretsId::try_decode_fbs(&fbs).expect_err("an 8-byte hash must be rejected");
+        assert!(
+            err.to_string().contains("SecretsId.hash") && err.to_string().contains("got 8 bytes"),
+            "got: {err}"
+        );
+
+        let bytes = build(32);
+        let fbs = flatbuffers::root::<FbsSecretsId>(&bytes).expect("well-formed");
+        assert!(
+            SecretsId::try_decode_fbs(&fbs).is_ok(),
+            "a 32-byte hash must still decode"
         );
     }
 }

--- a/rust/src/contract_interface/key.rs
+++ b/rust/src/contract_interface/key.rs
@@ -55,13 +55,39 @@ impl ContractInstanceId {
         self.0.as_slice()
     }
 
-    /// Build `ContractId` from the binary representation.
-    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, bs58::decode::Error> {
+    /// Parse a `ContractInstanceId` from its **base58 text** form — the inverse
+    /// of [`Self::encode`].
+    ///
+    /// The input is base58 *characters*, not the id's 32 raw bytes. It takes
+    /// `impl AsRef<[u8]>` only so that `&str`, `String` and `&[u8]` of base58
+    /// text all work; handing it a raw 32-byte id is a bug, and one that does
+    /// not look like a bug at the call site. Use
+    /// [`ContractInstanceId::new`] for raw bytes you already hold, or the
+    /// crate-internal `instance_id_from_fbs` for bytes off the wire.
+    ///
+    /// This was called `from_bytes`, documented as "build from the binary
+    /// representation". That name and doc caused four decode sites to feed it
+    /// raw wire bytes, which panicked on every well-formed request: a random
+    /// 32-byte id essentially never consists solely of base58 characters (the
+    /// alphabet is 58 of 256 byte values, so the odds are about 2e-21).
+    pub fn from_base58(bytes: impl AsRef<[u8]>) -> Result<Self, bs58::decode::Error> {
         let mut spec = [0; CONTRACT_KEY_SIZE];
         bs58::decode(bytes)
             .with_alphabet(bs58::Alphabet::BITCOIN)
             .onto(&mut spec)?;
         Ok(Self(spec))
+    }
+
+    /// Renamed to [`Self::from_base58`], which says what it actually does.
+    ///
+    /// Kept as a delegating alias so the rename is not a breaking change.
+    #[deprecated(
+        since = "0.8.5",
+        note = "renamed to `from_base58`: this parses base58 TEXT, not raw bytes. \
+                For a raw 32-byte id use `ContractInstanceId::new`."
+    )]
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, bs58::decode::Error> {
+        Self::from_base58(bytes)
     }
 }
 
@@ -77,7 +103,7 @@ impl FromStr for ContractInstanceId {
     type Err = bs58::decode::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ContractInstanceId::from_bytes(s)
+        ContractInstanceId::from_base58(s)
     }
 }
 
@@ -85,7 +111,7 @@ impl TryFrom<String> for ContractInstanceId {
     type Error = bs58::decode::Error;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        ContractInstanceId::from_bytes(s)
+        ContractInstanceId::from_base58(s)
     }
 }
 
@@ -269,28 +295,29 @@ fn code_hash_error(observed: Option<usize>) -> String {
 /// Decode a wire `ContractInstanceId`'s bytes, rejecting a wrong length instead
 /// of panicking.
 ///
-/// The flatbuffers verifier checks that a `(required)` vector is PRESENT; it
-/// does not check its LENGTH. So a peer can hand us an 8-byte `instance` that
-/// `flatbuffers::root` happily accepts, and the `try_into().unwrap()` this
-/// replaces then panicked with `TryFromSliceError`. There is no `catch_unwind`
-/// on this path and `panic = "abort"` is not set, so that unwound and killed
-/// the client's connection task: a wire-reachable remote panic.
-pub(crate) fn instance_id_from_fbs(data: &[u8]) -> Result<ContractInstanceId, WsApiError> {
-    let bytes: [u8; CONTRACT_KEY_SIZE] = data.try_into().map_err(|_| {
-        WsApiError::deserialization(format!(
-            "ContractKey.instance must be the {CONTRACT_KEY_SIZE}-byte contract instance id; \
-             got {} bytes. The flatbuffers verifier only checks that this required field is \
-             present, not that it is the right length, so a wrong-length id reaches the \
-             decoder and must be rejected here.",
-            data.len()
-        ))
-    })?;
-    Ok(ContractInstanceId::new(bytes))
+/// **This is the only correct way to turn wire bytes into a
+/// `ContractInstanceId`.** The wire carries the id as 32 RAW bytes — every
+/// encode site writes `key.as_bytes()` and the TypeScript SDK writes
+/// `Array.from(instance)` — so the decode is a length-checked pass-through and
+/// nothing else. In particular do NOT reach for
+/// [`ContractInstanceId::from_base58`]: that is a base58 *string* decoder, and
+/// pointing it at raw bytes is what broke `related_to`/`instance_id` decoding
+/// (it panicked on every well-formed request, because a random 32-byte id
+/// essentially never consists solely of base58 characters).
+///
+/// `field` is the schema path being decoded, so a GET, an UPDATE and a related
+/// contract each name their own field in the error.
+pub(crate) fn instance_id_from_fbs(
+    field: &str,
+    data: &[u8],
+) -> Result<ContractInstanceId, WsApiError> {
+    crate::client_api::fixed_size_field::<CONTRACT_KEY_SIZE>(field, data)
+        .map(ContractInstanceId::new)
 }
 
 impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
     fn try_decode_fbs(key: &FbsContractKey<'a>) -> Result<Self, WsApiError> {
-        let instance = instance_id_from_fbs(key.instance().data().bytes())?;
+        let instance = instance_id_from_fbs("ContractKey.instance", key.instance().data().bytes())?;
         // The `code` field carries the already-computed 32-byte code hash
         // (BLAKE3 of the wasm), so pass those bytes straight through. Calling
         // `CodeHash::from_code` here would hash the hash again -

--- a/rust/src/contract_interface/key.rs
+++ b/rust/src/contract_interface/key.rs
@@ -70,6 +70,14 @@ impl ContractInstanceId {
     /// raw wire bytes, which panicked on every well-formed request: a random
     /// 32-byte id essentially never consists solely of base58 characters (the
     /// alphabet is 58 of 256 byte values, so the odds are about 2e-21).
+    ///
+    /// Caveat, pre-existing and unchanged: `bs58`'s `onto` writes the decoded
+    /// bytes LEFT-aligned into the 32-byte buffer and reports how many it
+    /// wrote, which this discards. So base58 text that decodes to fewer than 32
+    /// bytes yields a zero-padded id rather than an error — `from_base58("1")`
+    /// is the all-zero id. Callers that accept untrusted text (freenet-core
+    /// parses URL path segments with this) get a well-formed but wrong id
+    /// rather than a rejection.
     pub fn from_base58(bytes: impl AsRef<[u8]>) -> Result<Self, bs58::decode::Error> {
         let mut spec = [0; CONTRACT_KEY_SIZE];
         bs58::decode(bytes)
@@ -81,8 +89,9 @@ impl ContractInstanceId {
     /// Renamed to [`Self::from_base58`], which says what it actually does.
     ///
     /// Kept as a delegating alias so the rename is not a breaking change.
+    // No `since`: the release this lands in is not decided here, and a guessed
+    // version is unfixable once published.
     #[deprecated(
-        since = "0.8.5",
         note = "renamed to `from_base58`: this parses base58 TEXT, not raw bytes. \
                 For a raw 32-byte id use `ContractInstanceId::new`."
     )]
@@ -305,8 +314,10 @@ fn code_hash_error(observed: Option<usize>) -> String {
 /// (it panicked on every well-formed request, because a random 32-byte id
 /// essentially never consists solely of base58 characters).
 ///
-/// `field` is the schema path being decoded, so a GET, an UPDATE and a related
-/// contract each name their own field in the error.
+/// `field` is the schema path being decoded. GET, SUBSCRIBE and UPDATE all pass
+/// `"ContractKey.instance.data"` because that genuinely is the field in all
+/// three (each request carries a `common.ContractKey`); the related-contract
+/// sites name their own distinct fields.
 pub(crate) fn instance_id_from_fbs(
     field: &str,
     data: &[u8],
@@ -317,7 +328,8 @@ pub(crate) fn instance_id_from_fbs(
 
 impl<'a> TryFromFbs<&FbsContractKey<'a>> for ContractKey {
     fn try_decode_fbs(key: &FbsContractKey<'a>) -> Result<Self, WsApiError> {
-        let instance = instance_id_from_fbs("ContractKey.instance", key.instance().data().bytes())?;
+        let instance =
+            instance_id_from_fbs("ContractKey.instance.data", key.instance().data().bytes())?;
         // The `code` field carries the already-computed 32-byte code hash
         // (BLAKE3 of the wasm), so pass those bytes straight through. Calling
         // `CodeHash::from_code` here would hash the hash again -

--- a/rust/src/contract_interface/update.rs
+++ b/rust/src/contract_interface/update.rs
@@ -142,7 +142,7 @@ impl<'a> TryFromFbs<&FbsRelatedContracts<'a>> for RelatedContracts<'a> {
             // the raw id and then unwrapped: it panicked on every well-formed
             // PUT carrying a related contract. See `instance_id_from_fbs`.
             let id = instance_id_from_fbs(
-                "RelatedContract.instance_id",
+                "RelatedContract.instance_id.data",
                 related.instance_id().data().bytes(),
             )?;
             let state = State::from(related.state().bytes());
@@ -334,7 +334,7 @@ impl<'a> TryFromFbs<&FbsUpdateData<'a>> for UpdateData<'a> {
                 let update = update_data.update_data_as_related_state_update().unwrap();
                 let state = State::from(update.state().bytes());
                 let related_to = instance_id_from_fbs(
-                    "RelatedStateUpdate.related_to",
+                    "RelatedStateUpdate.related_to.data",
                     update.related_to().data().bytes(),
                 )?;
                 Ok(UpdateData::RelatedState { related_to, state })
@@ -343,7 +343,7 @@ impl<'a> TryFromFbs<&FbsUpdateData<'a>> for UpdateData<'a> {
                 let update = update_data.update_data_as_related_delta_update().unwrap();
                 let delta = StateDelta::from(update.delta().bytes());
                 let related_to = instance_id_from_fbs(
-                    "RelatedDeltaUpdate.related_to",
+                    "RelatedDeltaUpdate.related_to.data",
                     update.related_to().data().bytes(),
                 )?;
                 Ok(UpdateData::RelatedDelta { related_to, delta })
@@ -355,7 +355,7 @@ impl<'a> TryFromFbs<&FbsUpdateData<'a>> for UpdateData<'a> {
                 let state = State::from(update.state().bytes());
                 let delta = StateDelta::from(update.delta().bytes());
                 let related_to = instance_id_from_fbs(
-                    "RelatedStateAndDeltaUpdate.related_to",
+                    "RelatedStateAndDeltaUpdate.related_to.data",
                     update.related_to().data().bytes(),
                 )?;
                 Ok(UpdateData::RelatedStateAndDelta {

--- a/rust/src/contract_interface/update.rs
+++ b/rust/src/contract_interface/update.rs
@@ -7,10 +7,11 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::client_api::{TryFromFbs, WsApiError};
+use crate::client_api::{unknown_union_discriminant, TryFromFbs, WsApiError};
 use crate::common_generated::common::{UpdateData as FbsUpdateData, UpdateDataType};
 use crate::generated::client_request::RelatedContracts as FbsRelatedContracts;
 
+use super::key::instance_id_from_fbs;
 use super::{ContractError, ContractInstanceId, State, StateDelta, CONTRACT_KEY_SIZE};
 
 /// An update to a contract state or any required related contracts to update that state.
@@ -136,7 +137,14 @@ impl<'a> TryFromFbs<&FbsRelatedContracts<'a>> for RelatedContracts<'a> {
     fn try_decode_fbs(related_contracts: &FbsRelatedContracts<'a>) -> Result<Self, WsApiError> {
         let mut map = HashMap::with_capacity(related_contracts.contracts().len());
         for related in related_contracts.contracts().iter() {
-            let id = ContractInstanceId::from_bytes(related.instance_id().data().bytes()).unwrap();
+            // Length-checked pass-through of the raw 32 bytes. This used to be
+            // `ContractInstanceId::from_bytes(..).unwrap()`, which base58-DECODED
+            // the raw id and then unwrapped: it panicked on every well-formed
+            // PUT carrying a related contract. See `instance_id_from_fbs`.
+            let id = instance_id_from_fbs(
+                "RelatedContract.instance_id",
+                related.instance_id().data().bytes(),
+            )?;
             let state = State::from(related.state().bytes());
             map.insert(id, Some(state));
         }
@@ -317,18 +325,27 @@ impl<'a> TryFromFbs<&FbsUpdateData<'a>> for UpdateData<'a> {
                 let delta = StateDelta::from(update.delta().bytes());
                 Ok(UpdateData::StateAndDelta { state, delta })
             }
+            // The three `related_to` decodes below were
+            // `ContractInstanceId::from_bytes(..).unwrap()`, which base58-DECODED
+            // bytes that are already the final raw id and then unwrapped the
+            // failure. Every well-formed related update panicked; see
+            // `instance_id_from_fbs`.
             UpdateDataType::RelatedStateUpdate => {
                 let update = update_data.update_data_as_related_state_update().unwrap();
                 let state = State::from(update.state().bytes());
-                let related_to =
-                    ContractInstanceId::from_bytes(update.related_to().data().bytes()).unwrap();
+                let related_to = instance_id_from_fbs(
+                    "RelatedStateUpdate.related_to",
+                    update.related_to().data().bytes(),
+                )?;
                 Ok(UpdateData::RelatedState { related_to, state })
             }
             UpdateDataType::RelatedDeltaUpdate => {
                 let update = update_data.update_data_as_related_delta_update().unwrap();
                 let delta = StateDelta::from(update.delta().bytes());
-                let related_to =
-                    ContractInstanceId::from_bytes(update.related_to().data().bytes()).unwrap();
+                let related_to = instance_id_from_fbs(
+                    "RelatedDeltaUpdate.related_to",
+                    update.related_to().data().bytes(),
+                )?;
                 Ok(UpdateData::RelatedDelta { related_to, delta })
             }
             UpdateDataType::RelatedStateAndDeltaUpdate => {
@@ -337,15 +354,20 @@ impl<'a> TryFromFbs<&FbsUpdateData<'a>> for UpdateData<'a> {
                     .unwrap();
                 let state = State::from(update.state().bytes());
                 let delta = StateDelta::from(update.delta().bytes());
-                let related_to =
-                    ContractInstanceId::from_bytes(update.related_to().data().bytes()).unwrap();
+                let related_to = instance_id_from_fbs(
+                    "RelatedStateAndDeltaUpdate.related_to",
+                    update.related_to().data().bytes(),
+                )?;
                 Ok(UpdateData::RelatedStateAndDelta {
                     related_to,
                     state,
                     delta,
                 })
             }
-            _ => unreachable!(),
+            // Reachable, not `unreachable!()`: the generated verifier for this
+            // union ends in `_ => Ok(())`, so any discriminant a client sets —
+            // including `NONE` — arrives here. See `unknown_union_discriminant`.
+            other => Err(unknown_union_discriminant("UpdateDataType", other.0)),
         }
     }
 }

--- a/rust/src/delegate_interface.rs
+++ b/rust/src/delegate_interface.rs
@@ -19,7 +19,7 @@ use crate::generated::client_request::{
 use crate::common_generated::common::SecretsId as FbsSecretsId;
 
 use crate::client_api::{fixed_size_field, unknown_union_discriminant, TryFromFbs, WsApiError};
-use crate::contract_interface::{RelatedContracts, UpdateData};
+use crate::contract_interface::{RelatedContracts, UpdateData, CONTRACT_KEY_SIZE};
 use crate::prelude::{ContractInstanceId, WrappedState};
 use crate::versioning::ContractContainer;
 use crate::{code_hash::CodeHash, prelude::Parameters};
@@ -286,8 +286,14 @@ impl<'a> TryFromFbs<&FbsDelegateKey<'a>> for DelegateKey {
         // future field added here needs the same treatment.
         let key_bytes =
             fixed_size_field::<DELEGATE_HASH_LENGTH>("DelegateKey.key", key.key().bytes())?;
-        let code_hash = CodeHash::try_from(key.code_hash().bytes())
-            .map_err(|e| WsApiError::deserialization(e.to_string()))?;
+        // `CodeHash::try_from` DOES length-check, so this field never panicked —
+        // but its error stringifies to "invalid data", naming neither the field
+        // nor the length. Symmetric treatment means the same message shape, not
+        // merely the same safety, so it goes through the same helper.
+        let code_hash = CodeHash::new(fixed_size_field::<CONTRACT_KEY_SIZE>(
+            "DelegateKey.code_hash",
+            key.code_hash().bytes(),
+        )?);
         Ok(DelegateKey {
             key: key_bytes,
             code_hash,

--- a/rust/src/delegate_interface.rs
+++ b/rust/src/delegate_interface.rs
@@ -18,7 +18,7 @@ use crate::generated::client_request::{
 
 use crate::common_generated::common::SecretsId as FbsSecretsId;
 
-use crate::client_api::{TryFromFbs, WsApiError};
+use crate::client_api::{fixed_size_field, unknown_union_discriminant, TryFromFbs, WsApiError};
 use crate::contract_interface::{RelatedContracts, UpdateData};
 use crate::prelude::{ContractInstanceId, WrappedState};
 use crate::versioning::ContractContainer;
@@ -278,8 +278,14 @@ impl Display for DelegateKey {
 
 impl<'a> TryFromFbs<&FbsDelegateKey<'a>> for DelegateKey {
     fn try_decode_fbs(key: &FbsDelegateKey<'a>) -> Result<Self, WsApiError> {
-        let mut key_bytes = [0; DELEGATE_HASH_LENGTH];
-        key_bytes.copy_from_slice(key.key().bytes());
+        // Both fields are `(required)` in the schema and BOTH need an explicit
+        // length check, because the verifier only guarantees presence. `key`
+        // used to be a bare `copy_from_slice` into a `[0; 32]`, which panics on
+        // a length mismatch, while `code_hash` one line below was already
+        // length-checked inside `CodeHash::try_from`. Keep them symmetric: a
+        // future field added here needs the same treatment.
+        let key_bytes =
+            fixed_size_field::<DELEGATE_HASH_LENGTH>("DelegateKey.key", key.key().bytes())?;
         let code_hash = CodeHash::try_from(key.code_hash().bytes())
             .map_err(|e| WsApiError::deserialization(e.to_string()))?;
         Ok(DelegateKey {
@@ -360,8 +366,13 @@ impl Display for SecretsId {
 
 impl<'a> TryFromFbs<&FbsSecretsId<'a>> for SecretsId {
     fn try_decode_fbs(key: &FbsSecretsId<'a>) -> Result<Self, WsApiError> {
-        let mut key_hash = [0; 32];
-        key_hash.copy_from_slice(key.hash().bytes().iter().as_ref());
+        // No production caller reaches this decoder today — `common.SecretsId`
+        // appears in no client-request table. It is fixed anyway because the
+        // `copy_from_slice` it replaces is a loaded gun for whoever wires it up:
+        // `hash` is `(required)`, which the verifier reads as "present", not
+        // "32 bytes", so the first client to send a short one would have
+        // panicked the connection task.
+        let key_hash = fixed_size_field::<32>("SecretsId.hash", key.hash().bytes())?;
         Ok(SecretsId {
             key: key.key().bytes().to_vec(),
             hash: key_hash,
@@ -623,7 +634,13 @@ impl<'a> TryFromFbs<&FbsInboundDelegateMsg<'a>> for InboundDelegateMsg<'a> {
                 };
                 Ok(InboundDelegateMsg::UserResponse(user_response))
             }
-            _ => unreachable!("invalid inbound delegate message type"),
+            // Reachable, not `unreachable!()`: the generated verifier for this
+            // union ends in `_ => Ok(())`, so any discriminant a client sets —
+            // including `NONE` — arrives here. See `unknown_union_discriminant`.
+            other => Err(unknown_union_discriminant(
+                "InboundDelegateMsgType",
+                other.0,
+            )),
         }
     }
 }

--- a/rust/src/versioning.rs
+++ b/rust/src/versioning.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    client_api::{TryFromFbs, WsApiError},
+    client_api::{unknown_union_discriminant, TryFromFbs, WsApiError},
     common_generated::common::{ContractContainer as FbsContractContainer, ContractType},
     contract_interface::{ContractInstanceId, ContractKey},
     generated::client_request::{DelegateContainer as FbsDelegateContainer, DelegateType},
@@ -114,7 +114,12 @@ impl<'a> TryFromFbs<&FbsDelegateContainer<'a>> for DelegateContainer {
                     Delegate::from((&data, &params)),
                 )))
             }
-            _ => unreachable!(),
+            // Reachable, not `unreachable!()`: the generated verifier for this
+            // union ends in `_ => Ok(())`, and the TypeScript SDK's
+            // `DelegateContainer` constructor takes `DelegateType.NONE` as its
+            // default argument, so NONE is a value first-party client code can
+            // realistically send. See `unknown_union_discriminant`.
+            other => Err(unknown_union_discriminant("DelegateType", other.0)),
         }
     }
 }
@@ -429,7 +434,12 @@ impl<'a> TryFromFbs<&FbsContractContainer<'a>> for ContractContainer {
                     key,
                 })))
             }
-            _ => unreachable!(),
+            // Reachable, not `unreachable!()`: the generated verifier for this
+            // union ends in `_ => Ok(())`, and the TypeScript SDK's
+            // `ContractContainer` constructor takes `ContractType.NONE` as its
+            // default argument, so NONE is a value first-party client code can
+            // realistically send on a PUT. See `unknown_union_discriminant`.
+            other => Err(unknown_union_discriminant("ContractType", other.0)),
         }
     }
 }


### PR DESCRIPTION
## Problem

Twelve sites on the FlatBuffers decode path either panicked the connection task or silently produced a wrong value, on input a client can actually send — eleven on the request-decode path, plus one encode site found during review. These were found by sweeping every `try_decode_fbs` impl after #85 fixed one instance of the first shape below; the sweep is exhaustive over `.bytes()` against every `try_into` / `try_from` / `copy_from_slice` / `from_bytes` / indexing form.

**Every one of these is FlatBuffers-only.** The native path decodes the same Rust enums via bincode and never reaches `try_decode_fbs`, and first-party tooling (fdev, riverctl, River UI) uses `encodingProtocol=native`. That is both why the class went unnoticed for years and why it lands entirely on third-party and browser clients — the same population that reported the original double-hash.

### Shape 1: a base58 decoder pointed at raw bytes (4 sites)

`RelatedStateUpdate.related_to`, `RelatedDeltaUpdate.related_to`, `RelatedStateAndDeltaUpdate.related_to` and `RelatedContract.instance_id` were decoded with:

```rust
ContractInstanceId::from_bytes(update.related_to().data().bytes()).unwrap()
```

`from_bytes` is `bs58::decode(..)` — a base58 **string** decoder backing `FromStr` — but its doc said "Build `ContractId` from the binary representation", and the wire carries the id as 32 raw bytes (every encode site writes `key.as_bytes()`; the TypeScript SDK writes `Array.from(instance)`).

This is not "malformed input panics". Sampling 200,000 random 32-byte ids, **zero** decode successfully: a valid base58 decode needs all 32 bytes to be base58 characters, and the alphabet is 58 of 256 byte values (expected rate 2e-21). So **every** FlatBuffers UPDATE carrying a related update, and every PUT carrying a related contract, panicked the client's connection task on correct input. The PUT case stayed hidden because the loop body only runs on a non-empty vector and the TypeScript suite's fixture passes `new RelatedContractsT([])`.

### Shape 2: length-unchecked `(required)` fields (4 sites)

`DelegateKey.key`, `SecretsId.hash`, `RegisterDelegate.cipher` and `RegisterDelegate.nonce` were read into fixed-size arrays with `copy_from_slice` or `try_from(..).unwrap()`. The verifier checks that a `(required)` vector is PRESENT, not that it is the right LENGTH (`Verifiable for Vector<T>` runs `verify_vector_range` and stops), so a short field passes verification and panics the decoder. Same shape #85 fixed for `ContractKey.instance`.

`DelegateKey` is on the normal delegate path (`ApplicationMessages` and `UnregisterDelegate`), and the TypeScript SDK exports `DelegateKey` as the raw generated type with no length validation — unlike `ContractKey`, which throws a `TypeError`. Note the decoder was already half-guarded: `code_hash` one line below `key` was length-checked via `CodeHash::try_from`.

`SecretsId::try_decode_fbs` has no production caller today; it is fixed anyway so the first client to reach it does not find a panic waiting.

### Shape 3: union discriminants matched with `unreachable!()` (4 sites)

`ContractType` (PUT), `DelegateType` (RegisterDelegate), `UpdateDataType` (UPDATE) and `InboundDelegateMsgType` (ApplicationMessages). Every generated union verifier ends in `_ => Ok(())`, and `visit_union` only rejects when the type and value fields disagree on presence — with both present it hands **any** unrecognized discriminant straight to the decoder's match.

Precisely which values get there is worth stating, because the obvious guess is wrong and an earlier revision of this PR asserted it: a `NONE` discriminant does **not** reach the decoder by the ordinary route. Both the Rust and TypeScript builders elide a field equal to its default (`FlatBufferBuilder::push_slot`), so `NONE` is written as absent and `visit_union` rejects the present-value/absent-type pair first. What reaches the match is an out-of-range discriminant, or a `NONE` written explicitly by an encoder that forces defaults or is not flatc-generated. Still wire-reachable, but by a different door — and the distinction matters for the test, below.

`ContractRequestType`, `DelegateRequestType` and `ClientRequestType` already returned an error here; these four did not. All seven now share one error shape, and `ClientRequestType` reports the offending value, which it previously omitted.

### Shape 4 (found in review): the encode half of shape 1

`HostResponse`'s three related-update variants wrote `related_to.encode()` — base58 **text** — into `common.ContractInstanceId.data`. The other six `ContractInstanceId` encode sites in the same function write `key.as_bytes()`, the TypeScript SDK reads the field as a raw `Uint8Array`, and this PR's own decoder now rejects anything that is not 32 raw bytes.

It survived because Rust only *encodes* host responses and only TypeScript *decodes* them, so no Rust round-trip test ever crossed it and no TS test reads `relatedTo` back out of a notification. It is in scope because leaving it would ship a decoder that rejects what our own encoder emits, and because it falsified a load-bearing claim in this PR's own doc comment.

## Approach

Three shapes, three shared mechanisms rather than nine local patches — the point is that the next field and the next union are covered by construction:

- **`client_api::fixed_size_field::<N>(field, data)`** for every fixed-size wire field, naming the schema path so the error says `RegisterDelegate.cipher must be exactly 32 bytes; got 16 bytes` rather than "invalid data". `instance_id_from_fbs` (added by #85) now delegates to it and takes the field name, so a GET, an UPDATE and a related contract each name their own field.
- **`client_api::unknown_union_discriminant(union, d)`** for every union match.
- **`ContractInstanceId::from_bytes` renamed to `from_base58`.** The name is the root cause of shape 1 — it is what made four call sites feed a base58 parser raw wire bytes without looking wrong. `from_bytes` remains as a delegating alias so the rename is **not** a breaking change, but it is `#[deprecated]`, so it warns.

  **Heads-up for the next stdlib bump.** freenet-core calls `ContractInstanceId::from_bytes` at four sites (`server/client_api.rs:604`, `server/path_handlers.rs:385, 652, 952`) and names it in prose at three more (`server/client_api.rs:584, 1206, 1294`). All four call sites are correct uses — they parse a base58 URL path segment — but core builds with `-D warnings`, so the bump PR needs those four renamed and ideally the three doc references too. Harvest also has one call site (`common/src/lib.rs:70`, pinned to stdlib 0.6, so it only trips on a future bump). River, freenet-git and delta have none. That ripple is the intended nudge; flagging it so it is not a surprise.

## Testing

**The sweep.** One test walks all 256 discriminants of all seven unions on the decode path, asserting none panics, and that both an out-of-range discriminant and an explicit `NONE` produce **the decoder's own error message** — not merely `is_err()`. That distinction is the point: asserting only `is_err()` would pass on a verifier rejection, which reaches none of the code this PR changes, and the sweep would silently degrade to zero decoder coverage the moment a schema change made verification fail earlier. The `NONE` case builds with `force_defaults(true)` so the zero is written explicitly and genuinely reaches the match arm.

**Two source-scrape pins** enforce the conventions across every file hosting a `TryFromFbs` impl: no wire field read with a conversion that panics on the wrong length, and no union matched with `unreachable!()`. This is what actually covers the *next* decoder — the sweep's `cases` array is hand-written, so it covers a new variant on an existing union for free but not a new union.

**Per-site pins.** Each of the nine sites also has its own test, so a partial revert cannot leave the suite green — the exact failure mode #85 shipped with, where the panic fix reached three call sites and only one was pinned. The round-trip tests use an instance id containing `0x00`, `0xff` and the base58-excluded `0`/`O`/`I`/`l` characters, so a revert to the base58 decode cannot pass by luck.

**Verified by reverting, not by reasoning.** 14 mutations applied one at a time against the committed tree — every fixed site, plus the encode site, plus each source-scrape pin. Every one fails its pin. No vacuous tests.

| reverted site | test that fails |
|---|---|
| `RelatedContract.instance_id` | `put_related_contract_round_trips_the_raw_instance_id`, `put_related_contract_wrong_length_id_is_rejected` |
| `RelatedStateUpdate.related_to` | `related_state_update_round_trips_the_raw_instance_id`, `related_to_wrong_length_is_rejected` |
| `RelatedDeltaUpdate.related_to` | `related_delta_update_round_trips_the_raw_instance_id` |
| `RelatedStateAndDeltaUpdate.related_to` | `related_state_and_delta_update_round_trips_the_raw_instance_id` |
| `UpdateDataType` / `DelegateType` / `ContractType` / `InboundDelegateMsgType` `unreachable!()` | `no_union_discriminant_panics_the_decoder` (each independently) |
| `DelegateKey.key` | `delegate_key_wrong_length_is_rejected_not_panicking` |
| `SecretsId.hash` | `secrets_id_wrong_length_hash_is_rejected_not_panicking` |
| `RegisterDelegate.cipher` / `.nonce` | `register_delegate_wrong_length_cipher_or_nonce_is_rejected` |
| `HostResponse` related-update encode | `host_response_encodes_related_to_as_raw_bytes` |
| either convention pin | `no_wire_field_is_read_with_a_panicking_conversion` / `union_matches_never_use_unreachable` |

`cargo fmt`, `cargo clippy --all-targets --features net -- -D warnings`, and the full suite (85 tests, up from 75) are clean. No schema change and no regenerated-flatbuffers churn: the diff is 7 hand-written files.

## What is clean, for the record

The sweep also cleared these, so they are not silently unaddressed:

- **Stream reassembly** (`client_api/streaming.rs`) is well-defended: `total == 0`, `total > MAX_TOTAL_CHUNKS`, `index >= total`, `state.total != total` and duplicate-chunk are all checked before the indexing, so the index is provably in range and the allocation is capped.
- **The encode side has no instance of this class.** No Rust code encodes a `ClientRequest` outside tests; response encoding writes raw bytes for both key parts.
- **The container decoders do not re-transform**: both recompute the key from params+code rather than trusting a wire hash, and `DelegateKey.code_hash` is a checked pass-through.
- **The three `host_response` unions** have the same verifier fallthrough but no Rust decoder — Rust only encodes host responses.

## Review

Five independent lenses (code-first, skeptical, testing, big-picture, and a wire-format/compat lens), each blind to the others. Every finding was fixed or answered; the second commit is the response. The highest-severity one — the encode-side base58 — came from the skeptical lens and expanded the scope of this PR by one site, which is called out above rather than deferred.

Two things reviewers raised that are deliberately **not** fixed here:

- `RelatedContracts::try_decode_fbs` pre-allocates `HashMap::with_capacity(contracts().len())` from a wire-controlled length, which is a memory-amplification vector rather than a panic. Pre-existing, a different class from this PR's scope, and its impact depends on freenet-core's frame cap. Worth its own issue.
- The TypeScript suite still builds `new RelatedContractsT([])` and has no test emitting a related UPDATE — the fixture shape that hid the PUT bug for years. The Rust builders now pin the decoder, but a captured TS-emitted PUT carrying a related contract would close it from the other side.

Refs freenet/freenet-core#4996

[AI-assisted - Claude]
