### PR TITLE
chore: release freenet-stdlib 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-07-27
+
 ### Fixed
 - **Related-contract decoding no longer panics on well-formed requests.**
   `RelatedStateUpdate.related_to`, `RelatedDeltaUpdate.related_to`,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-stdlib"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Problem

Three merged fixes to the FlatBuffers client-request boundary are sitting unreleased. None of them reaches a consumer until stdlib is published, and every one of them affects **third-party and browser clients specifically** — first-party tooling (fdev, riverctl, River UI) uses `encodingProtocol=native` and never touches these paths, which is why this class survived for years without anyone noticing.

## What ships

- **#85** — `ContractKey`'s code hash is passed through FBS decode instead of re-hashed. `CodeHash::from_code` was being applied to a field that already holds the 32-byte hash, producing BLAKE3(BLAKE3(wasm)) — a key that matches nothing, so **FlatBuffers UPDATE has been 100% broken since `844880e` (Nov 2023)**. Also hardens the instance field at the UPDATE, GET and SUBSCRIBE decode sites against a length mismatch the flatbuffers verifier does not check.
- **#87** — `WebApi::recv()` no longer discards a buffered response when the stream channel closes first. Both channels went ready simultaneously and `tokio::select!` chose between them at random, so the real error was replaced by a generic "channel closed" roughly half the time. `Stream::poll_next` had the same defect *deterministically*, dropping complete streamed responses every time.
- **#88** — twelve further sites on the same boundary. The worst: `ContractInstanceId::from_bytes` is a **base58 decoder** that was being applied to raw wire bytes. 200,000 sampled instance ids produced **zero** successful decodes, so every *correct* related-contract UPDATE or PUT panicked the connection task. Also fixes the encode half (`HostResponse` wrote base58 text into a field the TypeScript SDK reads as raw bytes), adds length checks on delegate keys and cipher/nonce, and converts four union discriminants that hit `unreachable!()` on input the generated verifier accepts.

## Consumer action required

`ContractInstanceId::from_bytes` is renamed to **`from_base58`**. The old name remains as a `#[deprecated]` delegating alias, so this is not a breaking change — but **freenet-core builds with `-D warnings`**, so the core bump PR must rename its call sites:

- `crates/core/src/server/client_api.rs`
- `crates/core/src/server/path_handlers.rs` (three sites)

All four are correct base58 uses; the rename exists because the misleading name is what caused the misuse twice. Harvest has one further site (`common/src/lib.rs`, currently pinned to 0.6). River, freenet-git and delta have none.

## Testing

Everything in these three PRs was mutation-verified rather than argued — each fix reverted individually, confirmed to fail its pin, restored. #88 alone applied 14 such mutations, including two source-scrape pins that forbid a panicking conversion on a wire field or an `unreachable!()` on a union anywhere a `TryFromFbs` impl lives.

CHANGELOG entries for all three are already on `main` under the new `[0.8.5]` heading.

[AI-assisted - Claude]