### PR TITLE
docs(contract-interface): bound the delta to an up-to-date peer

### DIFF
--- a/rust/src/contract_interface/trait_def.rs
+++ b/rust/src/contract_interface/trait_def.rs
@@ -64,8 +64,13 @@ use super::{
 /// applied should not affect the final state. Once all deltas are applied, the resulting
 /// state should be the same, regardless of the order in which the deltas were applied.
 ///
-/// Noncompliant behavior, such as failing to obey the commutativity rule, may result
-/// in the contract being deprioritized or removed from the p2p network.
+/// Implementations must also keep the delta negligible when the requesting peer's summary
+/// shows it already holds this state: the delta must not contain that state, or approach
+/// its size. See [`Self::get_state_delta`].
+///
+/// Noncompliant behavior, such as failing to obey the commutativity rule or returning a
+/// state-sized delta to a peer that is already up to date, may result in the contract
+/// being deprioritized or removed from the p2p network.
 pub trait ContractInterface {
     /// Verify that the state is valid, given the parameters.
     fn validate_state(
@@ -83,6 +88,11 @@ pub trait ContractInterface {
 
     /// Generate a concise summary of a state that can be used to create deltas
     /// relative to this state.
+    ///
+    /// The summary must be much smaller than the state it summarizes. A summary whose
+    /// size is comparable to the state defeats delta computation, and a summary that is
+    /// a copy of the state is always a bug. See [`Self::get_state_delta`] for the
+    /// delta-size requirement this summary feeds into.
     fn summarize_state(
         parameters: Parameters<'static>,
         state: State<'static>,
@@ -91,6 +101,33 @@ pub trait ContractInterface {
     /// Generate a state delta using a summary from the current state.
     /// This along with [`Self::summarize_state`] allows flexible and efficient
     /// state synchronization between peers.
+    ///
+    /// # The delta to an up-to-date peer must be negligible
+    ///
+    /// When `summary` shows that the requesting peer already holds everything this state
+    /// has, the delta carries no information, and its size has to reflect that.
+    ///
+    /// - **MUST NOT** return a delta that contains the state, or whose size approaches the
+    ///   state's. This is the actual defect. A `get_state_delta` that ignores `summary`
+    ///   and returns the whole state makes every reconciliation re-ship data the peer
+    ///   already holds, forever, and is the behavior that may get a contract
+    ///   deprioritized or removed from the network.
+    /// - **SHOULD** return a literally empty delta, `StateDelta::from(vec![])`. Peers read
+    ///   zero bytes as an unambiguous "converged" and skip the broadcast, so this is the
+    ///   cheapest and clearest answer.
+    /// - **Acceptable**: a small fixed amount of encoding framing. Serializing a delta
+    ///   struct whose fields are all `None` or empty costs about a byte per field with
+    ///   bincode, and tens of bytes with CBOR, since ciborium writes field names. That
+    ///   is not the unambiguous converged signal, so prefer zero, but it is not a defect
+    ///   and carries no penalty.
+    ///
+    /// What matters is delta size relative to state size, not the exact byte count. Twenty
+    /// bytes against a 500 KB state is fine. A state-sized delta is not.
+    ///
+    /// Building state with `freenet-scaffold` gets the empty case for free: its
+    /// `#[composable]` derive collapses an all-`None` delta struct to `None`, which the
+    /// contract maps to `StateDelta::from(vec![])`. A hand-rolled `get_state_delta` has
+    /// no such collapse and must add the check itself if it wants zero bytes.
     fn get_state_delta(
         parameters: Parameters<'static>,
         state: State<'static>,


### PR DESCRIPTION
## Problem

`ContractInterface`'s rustdoc says nothing about what `get_state_delta` owes a peer that is already up to date, and there is a real defect in the wild that it should rule out: one live contract ignores the `summary` argument entirely and returns its whole state as the delta, **25,403 bytes against a 24,832-byte state**. Every reconciliation re-ships data the peer already holds, it never converges with anyone, and it is currently 55.6% of all broadcast sends on the network (freenet/freenet-core#5056).

Core decides whether a neighbour is up to date by running `get_state_delta` against that neighbour's summary and reading an empty result as "converged" (`broadcast_queue.rs::fanout_send_needed` via `peer_summary_has_pending_state`), so this is load-bearing rather than a matter of efficiency.

## Approach

Doc comments only, no code or behavior change.

The obvious phrasing, "the delta to an up-to-date peer must be zero bytes", is **wrong as a hard rule**, and an earlier revision of this PR made that mistake. A contract that hand-rolls `get_state_delta` around a plain (non-`Option`) delta struct serializes an all-empty struct and returns roughly 20 bytes. Atlas does exactly this and is behaving correctly. A flat zero-byte rule would mark it noncompliant, which is the same false-positive shape as freenet/freenet-core#4295.

So the rustdoc states it in three tiers:

- **MUST NOT** return a delta containing the state, or approaching its size. This is the actual defect, and the only tier that carries the existing "may result in the contract being deprioritized or removed" consequence.
- **SHOULD** return a literally empty delta, `StateDelta::from(vec![])`, since zero bytes is the unambiguous converged signal.
- **Acceptable**: a small fixed amount of encoding framing from an all-empty delta struct. About a byte per field with bincode; tens of bytes with CBOR, because ciborium serializes structs as maps and writes the field names (`ciborium-0.2.2/src/ser/mod.rs:288`).

The discriminator is delta size **relative to state size**, not an absolute byte count: ~20 bytes against a 500 KB state versus a state-sized delta is five orders of magnitude, and no encoding choice moves a contract across that gap.

Also documented, since it is the actionable difference between two live apps: `freenet-scaffold`'s `#[composable]` derive collapses an all-`None` delta struct to `None` and so gets zero bytes for free (River), while a hand-rolled `get_state_delta` has to add that collapse itself (Atlas).

`summarize_state` gains the companion rule: the summary must be much smaller than the state, and a summary that is a copy of the state is always a bug. The offending contract fails this too, with summary == state == 24 KB.

## Testing

`cargo fmt --check` clean. `cargo doc --no-deps --features contract` produces no warnings from `trait_def.rs` and the new intra-doc links resolve; the 5 remaining warnings are pre-existing and in other files.

[AI-assisted - Claude]