### PR TITLE
fix(typescript)!: correlate host responses to requests by contract key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## [Unreleased]
 
+### TypeScript SDK — Breaking (npm package `@freenetorg/freenet-stdlib`; next release must be 0.4.0, not a patch)
+
+The npm package is versioned separately from the Rust crate. This release
+changes runtime behavior for existing callers, so on a 0.x line it takes a
+minor bump: **0.3.0 -> 0.4.0**, not 0.3.1.
+
+- **Host responses are now correlated to requests by contract key.**
+  `FreenetWsApi` previously resolved the *oldest* pending request of a type
+  with whatever response arrived, with no correlation at all. Two concurrent
+  `get()`s for different contracts whose answers came back out of order
+  therefore resolved into each other's promises — one contract's state
+  delivered to the other's caller, silently. This is reachable in practice, not
+  theoretical: freenet-core drives each contract operation on its own task and
+  publishes results as they complete, so responses arrive in completion order,
+  not request order.
+
+  Every `ContractResponse` carries the contract key (or, for `NotFound`, the
+  instance id), so requests now record the key they expect back and are matched
+  on it. A response that matches no pending request is dropped rather than
+  mis-delivered; the `ResponseHandler` callbacks still see it, so the legacy
+  callback API is unchanged.
+
+  One response settles *every* pending request for its key. Concurrent requests
+  for one contract are indistinguishable — the wire carries no request id — and
+  the node coalesces byte-identical concurrent UPDATEs into a single
+  transaction, emitting one result for both, so settling only the oldest would
+  strand the rest until the 30s timeout.
+
+- **`subscribe()` now waits for the host's confirmation.** It previously
+  returned a `Promise<void>` that resolved as soon as the request was *sent*,
+  and could never reject — a refused subscription (a subscriber-limit rejection,
+  for instance) left the awaited promise silently resolved. It now resolves on
+  `SubscribeResponse { subscribed: true }` and rejects on `subscribed: false`,
+  on a host error naming the contract, on connection close, or after
+  `REQUEST_TIMEOUT_MS`. **Callers who `await subscribe()` see behavior change**:
+  the call now blocks until the host answers, and can throw where it previously
+  could not. Fire-and-forget callers should add a rejection handler.
+
+- **A host error no longer fails every in-flight request.** Any single error
+  previously rejected every pending get, put and update across all contracts.
+  Errors are now scoped to the requests whose contract key the error message
+  names. An error naming no pending contract still fails everything, since it
+  may be connection-wide and must not leave callers waiting out the timeout.
+
 ### Breaking (next release must be 0.9.0, not a patch)
 - **`DelegateRequest::RegisterDelegateWithPredecessors`** removed (added in
   0.8.4). freenet-core's node-side handler for this request was disabled in

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -837,6 +837,16 @@ export class FreenetWsApi {
             // silent data mix-up this correlation exists to prevent — as it
             // also would be once any put has given up without an answer, which
             // is what `disarmLoneFallback` watches for.
+            //
+            // Known candidate for removal. This tier only earns its keep if the
+            // host's recomputed key really can differ from the container key a
+            // client sends; every consumer looked at so far derives that key
+            // correctly, and the test covering the divergence is synthetic, so
+            // there is no evidence either way yet. If someone establishes that
+            // divergence does not happen in practice, deleting the tier is a
+            // clean simplification — it removes this hazard by construction
+            // rather than fencing it. That is its own change with its own
+            // evidence, not a fold-in.
             this.resolveMatching(
               this.pendingPuts,
               put_response.key.encode(),

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -678,6 +678,33 @@ interface PendingRequest<T> {
 /** Default timeout for awaiting a response (30 seconds). */
 const REQUEST_TIMEOUT_MS = 30_000;
 
+/** How many abandoned request keys to remember. See `rememberAbandoned`. */
+const ABANDONED_KEY_MEMORY = 64;
+
+/** The base58 alphabet, as a single-character test. */
+const BASE58_CHAR = /[1-9A-HJ-NP-Za-km-z]/;
+
+/**
+ * Whether `message` names `key` as a whole base58 token.
+ *
+ * A plain substring test is not an identity test here. Base58 encodes each
+ * leading zero byte of an instance id as a leading `'1'`, so ids with a long
+ * run of leading zeros produce short, `'1'`-heavy strings, and one key's full
+ * encoding can be a literal prefix of another's. Requiring that the match is
+ * not butted up against another base58 character makes a prefix relationship
+ * stop counting as a mention.
+ */
+function mentionsKey(message: string, key: string): boolean {
+  for (let from = 0; ; from += 1) {
+    const at = message.indexOf(key, from);
+    if (at === -1) return false;
+    const before = at === 0 ? "" : message[at - 1];
+    const after = message[at + key.length] ?? "";
+    if (!BASE58_CHAR.test(before) && !BASE58_CHAR.test(after)) return true;
+    from = at;
+  }
+}
+
 /**
  * base58-encodes a contract instance id, or returns `null` when the id is
  * missing or not 32 bytes (so a malformed key degrades to "uncorrelated"
@@ -743,6 +770,14 @@ export class FreenetWsApi {
   private pendingPuts: PendingRequest<PutResponse>[] = [];
   private pendingUpdates: PendingRequest<UpdateResponse>[] = [];
   private pendingSubscribes: PendingRequest<void>[] = [];
+  /**
+   * Keys of requests that left a queue without ever getting their own answer —
+   * timed out, or failed by a connection-wide error. A late response for one of
+   * these must never be handed to a different request. See
+   * {@link rememberAbandoned} and the lone-put fall-back in
+   * {@link takeMatching}.
+   */
+  private abandonedKeys: string[] = [];
 
   /**
    * @constructor
@@ -996,6 +1031,7 @@ export class FreenetWsApi {
       const timer = setTimeout(() => {
         const idx = queue.findIndex((p) => p.timer === timer);
         if (idx !== -1) queue.splice(idx, 1);
+        this.rememberAbandoned(key);
         reject(new Error("Request timeout"));
       }, REQUEST_TIMEOUT_MS);
       queue.push({ resolve, reject, timer, key });
@@ -1024,8 +1060,10 @@ export class FreenetWsApi {
    *
    * In order:
    * 1. every request awaiting this exact key;
-   * 2. only when `allowLoneFallback` is set and exactly one request is in
-   *    flight, that request — see the put call site for why;
+   * 2. only when `allowLoneFallback` is set, exactly one request is in flight,
+   *    and this key is not one we have abandoned — that request; see the put
+   *    call site for why the tier exists and {@link rememberAbandoned} for why
+   *    it is fenced;
    * 3. otherwise nothing: an unmatched response is dropped rather than
    *    mis-delivered, and the requests keep waiting for their own answer (or
    *    for REQUEST_TIMEOUT_MS).
@@ -1051,11 +1089,43 @@ export class FreenetWsApi {
       taken = queue.filter((p) => p.key === key);
       for (const pending of taken) queue.splice(queue.indexOf(pending), 1);
     }
-    if (taken.length === 0 && allowLoneFallback && queue.length === 1) {
+    if (
+      taken.length === 0 &&
+      allowLoneFallback &&
+      queue.length === 1 &&
+      !(key !== null && this.abandonedKeys.includes(key))
+    ) {
       taken = queue.splice(0, 1);
     }
     for (const pending of taken) clearTimeout(pending.timer);
     return taken;
+  }
+
+  /**
+   * Remembers that a request for `key` left a queue without ever getting its
+   * own answer, so a late response for it can never be handed to some other
+   * request by the lone-put fall-back.
+   *
+   * Without this, the fall-back cannot tell "the key differs because the host
+   * recomputed it" — the case it exists for — from "the key differs because
+   * this answer belongs to a request that is already gone". Put A times out and
+   * is spliced out, the caller retries as put B, A's late answer arrives, and B
+   * resolves with A's response while B's real answer is later dropped against
+   * an empty queue. The conditions that cause a timeout are the same ones that
+   * make a late arrival likely, so this is not a remote corner.
+   *
+   * A bounded FIFO rather than an expiring record: nothing here needs to be
+   * exact, and a timer per entry would be another thing to leak. Sixty-four is
+   * far more abandonments than a healthy connection produces, and an entry
+   * ageing out only restores the previous behaviour for an answer that is by
+   * then extremely late.
+   */
+  private rememberAbandoned(key: string | null): void {
+    if (key === null || this.abandonedKeys.includes(key)) return;
+    this.abandonedKeys.push(key);
+    if (this.abandonedKeys.length > ABANDONED_KEY_MEMORY) {
+      this.abandonedKeys.shift();
+    }
   }
 
   /**
@@ -1090,9 +1160,10 @@ export class FreenetWsApi {
    * nothing to correlate on directly. freenet-stdlib renders the contract key
    * into that message (`ContractError`'s `Display`, as base58 of the instance
    * id), so this scans the message for the keys of the requests *we* are
-   * waiting on. Matching on our own keys rather than parsing the host's
-   * sentence means a change to the message wording degrades to the fall-back
-   * below instead of mis-attributing the failure.
+   * waiting on, as whole base58 tokens ({@link mentionsKey}). Matching on our
+   * own keys rather than parsing the host's sentence means a change to the
+   * message wording degrades to the fall-back below instead of mis-attributing
+   * the failure.
    *
    * When no pending key appears in the message the error cannot be attributed —
    * it may be connection-wide — so every pending request is failed, as before.
@@ -1110,7 +1181,9 @@ export class FreenetWsApi {
     const error = new Error(cause);
     let matched = false;
     for (const queue of this.allPendingQueues) {
-      const key = queue.find((p) => p.key !== null && cause.includes(p.key))?.key;
+      const key = queue.find(
+        (p) => p.key !== null && mentionsKey(cause, p.key)
+      )?.key;
       if (key === undefined) continue;
       matched = true;
       this.rejectMatching(queue, key, error);
@@ -1126,6 +1199,9 @@ export class FreenetWsApi {
       while (queue.length > 0) {
         const pending = queue.shift()!;
         clearTimeout(pending.timer);
+        // Same reasoning as the timeout path: these never got their own answer,
+        // so a late one must not be handed to a later request.
+        this.rememberAbandoned(pending.key);
         pending.reject(error);
       }
     }

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -838,6 +838,13 @@ export class FreenetWsApi {
             this.responseHandler.onContractNotFound(not_found_id);
             // `NotFound` carries only the instance id (host_response.fbs), which
             // is exactly what requests are correlated on.
+            //
+            // Only `pendingGets` is failed. A pending `subscribe()` for the same
+            // contract is deliberately left alone: the host answers a subscribe
+            // for a missing contract with an `Error` naming the contract, which
+            // `rejectForError` attributes, so the caller still fails fast rather
+            // than waiting out REQUEST_TIMEOUT_MS. If that ever stops holding,
+            // fail `pendingSubscribes` here too.
             this.rejectMatching(
               this.pendingGets,
               encodeInstanceId(not_found_id),

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -662,8 +662,15 @@ interface PendingRequest<T> {
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
   /**
-   * base58 contract instance id this request is correlated on, or `null` when
-   * the request did not carry a usable key. See {@link takeMatching}.
+   * base58 contract instance id this request is correlated on. See
+   * {@link takeMatching}.
+   *
+   * `null` only if the key could not be read off the outgoing request, which
+   * the schema makes unreachable through the typed API: `key` is `(required)`
+   * on `Get`, `Update`, `Subscribe` and `WasmContractV1` (client_request.fbs,
+   * common.fbs), so `sendRequest` throws while packing before the request is
+   * ever queued. A `null`-key entry therefore matches nothing and would settle
+   * by timeout; there is deliberately no fall-back tier for it.
    */
   key: string | null;
 }
@@ -716,8 +723,9 @@ function putRequestKey(put: PutT): string | null {
  * Responses are matched to requests **by contract key**, not by arrival order.
  * The node drives each contract operation on its own task and publishes results
  * as they complete, so a request issued first can be answered second; matching
- * by position would hand one request's answer to another. See
- * {@link takeMatching} for the rule and its fall-backs.
+ * by position would hand one request's answer to another. One response settles
+ * every pending request for its key, since concurrent requests for one contract
+ * are indistinguishable on the wire. See {@link takeMatching}.
  *
  * @example
  * Here's a simple example:
@@ -1005,7 +1013,7 @@ export class FreenetWsApi {
   }
 
   /**
-   * Removes and returns the pending request a response belongs to.
+   * Removes and returns every pending request a response settles.
    *
    * Contract operations carry no request id on the wire — the only identifying
    * field a response has is the contract key (`ContractResponse` in
@@ -1015,31 +1023,43 @@ export class FreenetWsApi {
    * answer to another.
    *
    * In order:
-   * 1. the oldest request awaiting this exact key (so same-key concurrency stays
-   *    FIFO among itself);
-   * 2. the oldest request whose key could not be determined when it was sent;
-   * 3. only when `allowLoneFallback` is set and exactly one request is in
+   * 1. every request awaiting this exact key;
+   * 2. only when `allowLoneFallback` is set and exactly one request is in
    *    flight, that request — see the put call site for why;
-   * 4. otherwise nothing: an unmatched response is dropped rather than
+   * 3. otherwise nothing: an unmatched response is dropped rather than
    *    mis-delivered, and the requests keep waiting for their own answer (or
    *    for REQUEST_TIMEOUT_MS).
+   *
+   * Tier 1 settles *all* same-key requests, not just the oldest, because the
+   * client cannot tell them apart — the wire has no request id, and freenet-core
+   * drops its internal `RequestId` before `ClientEventsProxy::send`. Settling
+   * one and leaving the rest queued is not a safe default: the node coalesces
+   * byte-identical concurrent UPDATEs into a single transaction (its
+   * `RequestRouter` dedup) and emits one result for both, so the extra callers
+   * would wait out REQUEST_TIMEOUT_MS for an answer that is never coming twice.
+   * The cost is that two same-key requests with genuinely different outcomes
+   * both take the first outcome; with no id on the wire there is nothing better
+   * available, and asking one question twice deserves one answer.
    */
   private takeMatching<T>(
     queue: PendingRequest<T>[],
     key: string | null,
     allowLoneFallback = false
-  ): PendingRequest<T> | undefined {
-    let idx = key === null ? -1 : queue.findIndex((p) => p.key === key);
-    if (idx === -1) idx = queue.findIndex((p) => p.key === null);
-    if (idx === -1 && allowLoneFallback && queue.length === 1) idx = 0;
-    if (idx === -1) return undefined;
-    const [pending] = queue.splice(idx, 1);
-    clearTimeout(pending.timer);
-    return pending;
+  ): PendingRequest<T>[] {
+    let taken: PendingRequest<T>[] = [];
+    if (key !== null) {
+      taken = queue.filter((p) => p.key === key);
+      for (const pending of taken) queue.splice(queue.indexOf(pending), 1);
+    }
+    if (taken.length === 0 && allowLoneFallback && queue.length === 1) {
+      taken = queue.splice(0, 1);
+    }
+    for (const pending of taken) clearTimeout(pending.timer);
+    return taken;
   }
 
   /**
-   * Resolves the pending request this response belongs to, if any.
+   * Resolves every pending request this response settles.
    */
   private resolveMatching<T>(
     queue: PendingRequest<T>[],
@@ -1047,18 +1067,20 @@ export class FreenetWsApi {
     value: T,
     allowLoneFallback = false
   ): void {
-    this.takeMatching(queue, key, allowLoneFallback)?.resolve(value);
+    for (const pending of this.takeMatching(queue, key, allowLoneFallback)) {
+      pending.resolve(value);
+    }
   }
 
   /**
-   * Rejects the pending request this response belongs to, if any.
+   * Rejects every pending request this response settles.
    */
   private rejectMatching<T>(
     queue: PendingRequest<T>[],
     key: string | null,
     error: Error
   ): void {
-    this.takeMatching(queue, key)?.reject(error);
+    for (const pending of this.takeMatching(queue, key)) pending.reject(error);
   }
 
   /**
@@ -1077,10 +1099,12 @@ export class FreenetWsApi {
    * That keeps a genuinely fatal error from leaving callers hanging for the
    * full timeout.
    *
-   * Residual imprecision, deliberately accepted: if a get and an update for the
-   * same contract are both in flight, an error naming that contract fails both.
-   * Bounding the blast radius to one contract is the point; the host does not
-   * say which operation failed.
+   * Residual imprecision, deliberately accepted: every in-flight request naming
+   * that contract fails, across operations (a get and an update on the same
+   * contract both fail) and across duplicates (two concurrent gets on it both
+   * fail). Bounding the blast radius to one contract is the point; the host says
+   * neither which operation failed nor which of two identical requests, so
+   * failing all of them beats stranding the ones that are not the oldest.
    */
   private rejectForError(cause: string): void {
     const error = new Error(cause);

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -678,9 +678,6 @@ interface PendingRequest<T> {
 /** Default timeout for awaiting a response (30 seconds). */
 const REQUEST_TIMEOUT_MS = 30_000;
 
-/** How many abandoned request keys to remember. See `rememberAbandoned`. */
-const ABANDONED_KEY_MEMORY = 64;
-
 /** The base58 alphabet, as a single-character test. */
 const BASE58_CHAR = /[1-9A-HJ-NP-Za-km-z]/;
 
@@ -771,13 +768,14 @@ export class FreenetWsApi {
   private pendingUpdates: PendingRequest<UpdateResponse>[] = [];
   private pendingSubscribes: PendingRequest<void>[] = [];
   /**
-   * Keys of requests that left a queue without ever getting their own answer —
-   * timed out, or failed by a connection-wide error. A late response for one of
-   * these must never be handed to a different request. See
-   * {@link rememberAbandoned} and the lone-put fall-back in
-   * {@link takeMatching}.
+   * Whether the lone-put fall-back in {@link takeMatching} may still fire.
+   *
+   * Cleared for good once any put leaves the queue without a `PutResponse` of
+   * its own, because from then on an unmatched put answer might belong to that
+   * departed request rather than to the survivor. See
+   * {@link disarmLoneFallback}.
    */
-  private abandonedKeys: string[] = [];
+  private loneFallbackArmed = true;
 
   /**
    * @constructor
@@ -836,7 +834,9 @@ export class FreenetWsApi {
             // differ from the container key the client supplied, so a single
             // in-flight put still claims the response. With two or more in
             // flight the answer would be a guess, and a guess here is the
-            // silent data mix-up this correlation exists to prevent.
+            // silent data mix-up this correlation exists to prevent — as it
+            // also would be once any put has given up without an answer, which
+            // is what `disarmLoneFallback` watches for.
             this.resolveMatching(
               this.pendingPuts,
               put_response.key.encode(),
@@ -1031,7 +1031,7 @@ export class FreenetWsApi {
       const timer = setTimeout(() => {
         const idx = queue.findIndex((p) => p.timer === timer);
         if (idx !== -1) queue.splice(idx, 1);
-        this.rememberAbandoned(key);
+        this.disarmLoneFallback(queue);
         reject(new Error("Request timeout"));
       }, REQUEST_TIMEOUT_MS);
       queue.push({ resolve, reject, timer, key });
@@ -1060,10 +1060,10 @@ export class FreenetWsApi {
    *
    * In order:
    * 1. every request awaiting this exact key;
-   * 2. only when `allowLoneFallback` is set, exactly one request is in flight,
-   *    and this key is not one we have abandoned — that request; see the put
-   *    call site for why the tier exists and {@link rememberAbandoned} for why
-   *    it is fenced;
+   * 2. only when `allowLoneFallback` is set, no put has yet given up without an
+   *    answer, and exactly one request is in flight — that request; see the put
+   *    call site for why the tier exists and {@link disarmLoneFallback} for why
+   *    it is fenced, and why the fence cannot be keyed on the contract key;
    * 3. otherwise nothing: an unmatched response is dropped rather than
    *    mis-delivered, and the requests keep waiting for their own answer (or
    *    for REQUEST_TIMEOUT_MS).
@@ -1099,8 +1099,8 @@ export class FreenetWsApi {
     if (
       taken.length === 0 &&
       allowLoneFallback &&
-      queue.length === 1 &&
-      !(key !== null && this.abandonedKeys.includes(key))
+      this.loneFallbackArmed &&
+      queue.length === 1
     ) {
       taken = queue.splice(0, 1);
     }
@@ -1109,30 +1109,34 @@ export class FreenetWsApi {
   }
 
   /**
-   * Remembers that a request for `key` left a queue without ever getting its
-   * own answer, so a late response for it can never be handed to some other
-   * request by the lone-put fall-back.
+   * Disarms the lone-put fall-back, permanently, once a put has left `queue`
+   * without a `PutResponse` of its own. A no-op for the other queues, since the
+   * fall-back is wired only for puts.
    *
-   * Without this, the fall-back cannot tell "the key differs because the host
-   * recomputed it" — the case it exists for — from "the key differs because
-   * this answer belongs to a request that is already gone". Put A times out and
-   * is spliced out, the caller retries as put B, A's late answer arrives, and B
-   * resolves with A's response while B's real answer is later dropped against
-   * an empty queue. The conditions that cause a timeout are the same ones that
-   * make a late arrival likely, so this is not a remote corner.
+   * The hazard: put A times out and is spliced out, the caller retries as put
+   * B, A's late answer arrives, nothing matches it by key, exactly one put is
+   * queued — and B resolves with A's response, while B's real answer is later
+   * dropped against an empty queue. The conditions that cause the timeout are
+   * the same ones that make a late arrival likely.
    *
-   * A bounded FIFO rather than an expiring record: nothing here needs to be
-   * exact, and a timer per entry would be another thing to leak. Sixty-four is
-   * far more abandonments than a healthy connection produces, and an entry
-   * ageing out only restores the previous behaviour for an answer that is by
-   * then extremely late.
+   * Why this is not keyed on the contract key. An earlier attempt remembered
+   * the keys of abandoned requests and refused to lone-match those. That cannot
+   * work here: the key a put is *queued* under is the client's container key,
+   * while the key its answer *arrives* under is the host's recomputed one, and
+   * those differing is the entire reason this fall-back exists. Comparing them
+   * closes the hazard only when they happen to agree — which is precisely when
+   * an exact match would have handled it anyway.
+   *
+   * So the fence ignores keys and asks a question it can actually answer: has
+   * any put given up without an answer? A single sticky flag rather than a
+   * count-since-queued, because a put abandoned *before* the survivor was
+   * queued can still have an answer in flight — the delta would be zero in
+   * exactly the sequence above and let it through. Sticky costs a divergent-key
+   * put a timeout instead of a resolution once the connection has seen a
+   * timeout, which is the safe direction: a late answer, not a wrong one.
    */
-  private rememberAbandoned(key: string | null): void {
-    if (key === null || this.abandonedKeys.includes(key)) return;
-    this.abandonedKeys.push(key);
-    if (this.abandonedKeys.length > ABANDONED_KEY_MEMORY) {
-      this.abandonedKeys.shift();
-    }
+  private disarmLoneFallback(queue: PendingRequest<any>[]): void {
+    if (queue === this.pendingPuts) this.loneFallbackArmed = false;
   }
 
   /**
@@ -1151,13 +1155,21 @@ export class FreenetWsApi {
 
   /**
    * Rejects every pending request this response settles.
+   *
+   * Every departure through here disarms the lone-put fall-back. A rejection is
+   * never a put's own `PutResponse`: the `NotFound` and refused-`SubscribeResponse`
+   * callers do not touch puts at all, and the one that does — the exact-match
+   * branch of {@link rejectForError} — attributes a failure by finding the key
+   * in a message, which does not stop the real answer arriving afterwards.
    */
   private rejectMatching<T>(
     queue: PendingRequest<T>[],
     key: string | null,
     error: Error
   ): void {
-    for (const pending of this.takeMatching(queue, key)) pending.reject(error);
+    const taken = this.takeMatching(queue, key);
+    if (taken.length > 0) this.disarmLoneFallback(queue);
+    for (const pending of taken) pending.reject(error);
   }
 
   /**
@@ -1208,7 +1220,7 @@ export class FreenetWsApi {
         clearTimeout(pending.timer);
         // Same reasoning as the timeout path: these never got their own answer,
         // so a late one must not be handed to a later request.
-        this.rememberAbandoned(pending.key);
+        this.disarmLoneFallback(queue);
         pending.reject(error);
       }
     }

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -763,10 +763,16 @@ export class FreenetWsApi {
   private responseHandler: ResponseHandler;
   private reassembly: ReassemblyBuffer = new ReassemblyBuffer();
   private nextStreamId = 0;
-  private pendingGets: PendingRequest<GetResponse>[] = [];
-  private pendingPuts: PendingRequest<PutResponse>[] = [];
-  private pendingUpdates: PendingRequest<UpdateResponse>[] = [];
-  private pendingSubscribes: PendingRequest<void>[] = [];
+  // `readonly` is load-bearing, not decoration: `disarmLoneFallback` identifies
+  // the put queue by reference (`queue === this.pendingPuts`), so reassigning
+  // one of these — say `this.pendingPuts = this.pendingPuts.filter(...)` in some
+  // later cleanup — would silently turn that check into a permanent no-op, with
+  // no compiler error and no failing test. Every mutation goes through
+  // splice/shift/push instead.
+  private readonly pendingGets: PendingRequest<GetResponse>[] = [];
+  private readonly pendingPuts: PendingRequest<PutResponse>[] = [];
+  private readonly pendingUpdates: PendingRequest<UpdateResponse>[] = [];
+  private readonly pendingSubscribes: PendingRequest<void>[] = [];
   /**
    * Whether the lone-put fall-back in {@link takeMatching} may still fire.
    *

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -657,8 +657,68 @@ function resolveWebSocket(): typeof WebSocket {
   }
 }
 
+interface PendingRequest<T> {
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+  /**
+   * base58 contract instance id this request is correlated on, or `null` when
+   * the request did not carry a usable key. See {@link takeMatching}.
+   */
+  key: string | null;
+}
+
+/** Default timeout for awaiting a response (30 seconds). */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 /**
- * The `FreenetWsApi` provides the API to manage the connection to the host, handle responses, and send requests.
+ * base58-encodes a contract instance id, or returns `null` when the id is
+ * missing or not 32 bytes (so a malformed key degrades to "uncorrelated"
+ * rather than throwing on the response path).
+ */
+function encodeInstanceId(
+  data: number[] | Uint8Array | null | undefined
+): string | null {
+  if (!data) return null;
+  const bytes = data instanceof Uint8Array ? data : Uint8Array.from(data);
+  if (bytes.length !== 32) return null;
+  return base58.encode(bytes);
+}
+
+/** base58 instance id of a wire `ContractKey`, or `null` when unusable. */
+function instanceIdOf(key: ContractKeyT | null | undefined): string | null {
+  return encodeInstanceId(key?.instance?.data);
+}
+
+/**
+ * base58 instance id a `Put` request expects back.
+ *
+ * The node recomputes a put's key from the contract code and parameters
+ * (`ContractKey::from_params_and_code`), so the key embedded in the container
+ * is what the *client* believes it is putting. It is the only correlation
+ * material a put carries; {@link FreenetWsApi.handleResponse} falls back to the
+ * lone in-flight put when the host disagrees.
+ */
+function putRequestKey(put: PutT): string | null {
+  return instanceIdOf(put.container?.contract?.key);
+}
+
+/**
+ * The `FreenetWsApi` provides the API to manage the connection to the host,
+ * handle responses, and send requests.
+ *
+ * Two APIs coexist and both fire for every response. The `ResponseHandler`
+ * callbacks see everything the host sends, including update notifications and
+ * responses nothing is waiting on. The promise-returning methods ({@link get},
+ * {@link put}, {@link update}, {@link subscribe}) additionally settle the one
+ * request a response belongs to.
+ *
+ * Responses are matched to requests **by contract key**, not by arrival order.
+ * The node drives each contract operation on its own task and publishes results
+ * as they complete, so a request issued first can be answered second; matching
+ * by position would hand one request's answer to another. See
+ * {@link takeMatching} for the rule and its fall-backs.
+ *
  * @example
  * Here's a simple example:
  * ```
@@ -666,15 +726,6 @@ function resolveWebSocket(): typeof WebSocket {
  * const freenetApi = new FreenetWsApi(API_URL, handler);
  * ```
  */
-interface PendingRequest<T> {
-  resolve: (value: T) => void;
-  reject: (reason: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}
-
-/** Default timeout for awaiting a response (30 seconds). */
-const REQUEST_TIMEOUT_MS = 30_000;
-
 export class FreenetWsApi {
   private ws: WebSocket;
   private responseHandler: ResponseHandler;
@@ -683,6 +734,7 @@ export class FreenetWsApi {
   private pendingGets: PendingRequest<GetResponse>[] = [];
   private pendingPuts: PendingRequest<PutResponse>[] = [];
   private pendingUpdates: PendingRequest<UpdateResponse>[] = [];
+  private pendingSubscribes: PendingRequest<void>[] = [];
 
   /**
    * @constructor
@@ -737,21 +789,39 @@ export class FreenetWsApi {
               host_resp.contractResponse as PutResponseT
             );
             this.responseHandler.onContractPut(put_response);
-            this.resolveNext(this.pendingPuts, put_response);
+            // `allowLoneFallback`: the host's key is authoritative and may
+            // differ from the container key the client supplied, so a single
+            // in-flight put still claims the response. With two or more in
+            // flight the answer would be a guess, and a guess here is the
+            // silent data mix-up this correlation exists to prevent.
+            this.resolveMatching(
+              this.pendingPuts,
+              put_response.key.encode(),
+              put_response,
+              true
+            );
             break;
           case ContractResponseType.GetResponse:
             const get_response = GetResponse.fromGetResponseT(
               host_resp.contractResponse as GetResponseT
             );
             this.responseHandler.onContractGet(get_response);
-            this.resolveNext(this.pendingGets, get_response);
+            this.resolveMatching(
+              this.pendingGets,
+              get_response.key.encode(),
+              get_response
+            );
             break;
           case ContractResponseType.UpdateResponse:
             const update_response = UpdateResponse.fromUpdateResponseT(
               host_resp.contractResponse as UpdateResponseT
             );
             this.responseHandler.onContractUpdate(update_response);
-            this.resolveNext(this.pendingUpdates, update_response);
+            this.resolveMatching(
+              this.pendingUpdates,
+              update_response.key.encode(),
+              update_response
+            );
             break;
           case ContractResponseType.UpdateNotification:
             const update_notification =
@@ -766,7 +836,13 @@ export class FreenetWsApi {
             const not_found = host_resp.contractResponse as NotFoundT;
             const not_found_id = new Uint8Array(not_found.instanceId?.data ?? []);
             this.responseHandler.onContractNotFound(not_found_id);
-            this.rejectNext(this.pendingGets, new Error("Contract not found"));
+            // `NotFound` carries only the instance id (host_response.fbs), which
+            // is exactly what requests are correlated on.
+            this.rejectMatching(
+              this.pendingGets,
+              encodeInstanceId(not_found_id),
+              new Error("Contract not found")
+            );
             break;
           case ContractResponseType.SubscribeResponse:
             const sub_resp = host_resp.contractResponse as SubscribeResponseT;
@@ -776,6 +852,21 @@ export class FreenetWsApi {
               : undefined;
             const sub_key = new ContractKey(sub_instance, sub_code);
             this.responseHandler.onSubscribeResponse?.(sub_key, sub_resp.subscribed);
+            if (sub_resp.subscribed) {
+              this.resolveMatching(
+                this.pendingSubscribes,
+                sub_key.encode(),
+                undefined
+              );
+            } else {
+              this.rejectMatching(
+                this.pendingSubscribes,
+                sub_key.encode(),
+                new Error(
+                  `Host reported contract ${sub_key.encode()} as not subscribed`
+                )
+              );
+            }
             break;
           default:
             const cause = "Contract response type not implemented";
@@ -803,7 +894,7 @@ export class FreenetWsApi {
             : "unknown error";
         const host_error: HostError = { cause: error_cause };
         this.responseHandler.onErr(host_error);
-        this.rejectAllPending(new Error(error_cause));
+        this.rejectForError(error_cause);
         break;
       case HostResponseType.StreamChunk: {
         const streamChunk = response.response as StreamChunkT;
@@ -882,44 +973,125 @@ export class FreenetWsApi {
    * Enqueues a pending response and returns a promise that resolves
    * when the matching response arrives, or rejects on timeout.
    */
-  private awaitResponse<T>(queue: PendingRequest<T>[]): Promise<T> {
+  private awaitResponse<T>(
+    queue: PendingRequest<T>[],
+    key: string | null
+  ): Promise<T> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         const idx = queue.findIndex((p) => p.timer === timer);
         if (idx !== -1) queue.splice(idx, 1);
         reject(new Error("Request timeout"));
       }, REQUEST_TIMEOUT_MS);
-      queue.push({ resolve, reject, timer });
+      queue.push({ resolve, reject, timer, key });
     });
   }
 
-  /**
-   * Resolves the oldest pending request in a queue.
-   */
-  private resolveNext<T>(queue: PendingRequest<T>[], value: T): void {
-    const pending = queue.shift();
-    if (pending) {
-      clearTimeout(pending.timer);
-      pending.resolve(value);
-    }
+  /** Every queue of awaited responses, for connection-wide failures. */
+  private get allPendingQueues(): PendingRequest<any>[][] {
+    return [
+      this.pendingGets,
+      this.pendingPuts,
+      this.pendingUpdates,
+      this.pendingSubscribes,
+    ];
   }
 
   /**
-   * Rejects the oldest pending request in a queue.
+   * Removes and returns the pending request a response belongs to.
+   *
+   * Contract operations carry no request id on the wire — the only identifying
+   * field a response has is the contract key (`ContractResponse` in
+   * host_response.fbs), so that is what requests are correlated on. Responses
+   * arrive in completion order, not request order, because the node drives each
+   * operation on its own task, so matching by position would hand one request's
+   * answer to another.
+   *
+   * In order:
+   * 1. the oldest request awaiting this exact key (so same-key concurrency stays
+   *    FIFO among itself);
+   * 2. the oldest request whose key could not be determined when it was sent;
+   * 3. only when `allowLoneFallback` is set and exactly one request is in
+   *    flight, that request — see the put call site for why;
+   * 4. otherwise nothing: an unmatched response is dropped rather than
+   *    mis-delivered, and the requests keep waiting for their own answer (or
+   *    for REQUEST_TIMEOUT_MS).
    */
-  private rejectNext<T>(queue: PendingRequest<T>[], error: Error): void {
-    const pending = queue.shift();
-    if (pending) {
-      clearTimeout(pending.timer);
-      pending.reject(error);
+  private takeMatching<T>(
+    queue: PendingRequest<T>[],
+    key: string | null,
+    allowLoneFallback = false
+  ): PendingRequest<T> | undefined {
+    let idx = key === null ? -1 : queue.findIndex((p) => p.key === key);
+    if (idx === -1) idx = queue.findIndex((p) => p.key === null);
+    if (idx === -1 && allowLoneFallback && queue.length === 1) idx = 0;
+    if (idx === -1) return undefined;
+    const [pending] = queue.splice(idx, 1);
+    clearTimeout(pending.timer);
+    return pending;
+  }
+
+  /**
+   * Resolves the pending request this response belongs to, if any.
+   */
+  private resolveMatching<T>(
+    queue: PendingRequest<T>[],
+    key: string | null,
+    value: T,
+    allowLoneFallback = false
+  ): void {
+    this.takeMatching(queue, key, allowLoneFallback)?.resolve(value);
+  }
+
+  /**
+   * Rejects the pending request this response belongs to, if any.
+   */
+  private rejectMatching<T>(
+    queue: PendingRequest<T>[],
+    key: string | null,
+    error: Error
+  ): void {
+    this.takeMatching(queue, key)?.reject(error);
+  }
+
+  /**
+   * Fails the requests a host `Error` response refers to.
+   *
+   * The wire `Error` carries only a message (host_response.fbs), so there is
+   * nothing to correlate on directly. freenet-stdlib renders the contract key
+   * into that message (`ContractError`'s `Display`, as base58 of the instance
+   * id), so this scans the message for the keys of the requests *we* are
+   * waiting on. Matching on our own keys rather than parsing the host's
+   * sentence means a change to the message wording degrades to the fall-back
+   * below instead of mis-attributing the failure.
+   *
+   * When no pending key appears in the message the error cannot be attributed —
+   * it may be connection-wide — so every pending request is failed, as before.
+   * That keeps a genuinely fatal error from leaving callers hanging for the
+   * full timeout.
+   *
+   * Residual imprecision, deliberately accepted: if a get and an update for the
+   * same contract are both in flight, an error naming that contract fails both.
+   * Bounding the blast radius to one contract is the point; the host does not
+   * say which operation failed.
+   */
+  private rejectForError(cause: string): void {
+    const error = new Error(cause);
+    let matched = false;
+    for (const queue of this.allPendingQueues) {
+      const key = queue.find((p) => p.key !== null && cause.includes(p.key))?.key;
+      if (key === undefined) continue;
+      matched = true;
+      this.rejectMatching(queue, key, error);
     }
+    if (!matched) this.rejectAllPending(error);
   }
 
   /**
    * Rejects all pending requests across all queues.
    */
   private rejectAllPending(error: Error): void {
-    for (const queue of [this.pendingGets, this.pendingPuts, this.pendingUpdates]) {
+    for (const queue of this.allPendingQueues) {
       while (queue.length > 0) {
         const pending = queue.shift()!;
         clearTimeout(pending.timer);
@@ -937,7 +1109,7 @@ export class FreenetWsApi {
       ClientRequestType.ContractRequest,
       new ContractRequestT(ContractRequestType.Put, put)
     ));
-    return this.awaitResponse(this.pendingPuts);
+    return this.awaitResponse(this.pendingPuts, putRequestKey(put));
   }
 
   /**
@@ -949,7 +1121,7 @@ export class FreenetWsApi {
       ClientRequestType.ContractRequest,
       new ContractRequestT(ContractRequestType.Update, update)
     ));
-    return this.awaitResponse(this.pendingUpdates);
+    return this.awaitResponse(this.pendingUpdates, instanceIdOf(update.key));
   }
 
   /**
@@ -961,11 +1133,18 @@ export class FreenetWsApi {
       ClientRequestType.ContractRequest,
       new ContractRequestT(ContractRequestType.Get, get)
     ));
-    return this.awaitResponse(this.pendingGets);
+    return this.awaitResponse(this.pendingGets, instanceIdOf(get.key));
   }
 
   /**
-   * Sends a subscribe request to the host through websocket
+   * Sends a subscribe request and waits for the host to confirm it.
+   *
+   * Resolves once the host answers with `SubscribeResponse { subscribed: true }`
+   * for this contract. Rejects if the host answers `subscribed: false` (for
+   * instance when a subscriber limit is reached), reports an error naming the
+   * contract, closes the connection, or does not answer within
+   * REQUEST_TIMEOUT_MS.
+   *
    * @param subscribe - The `SubscribeRequest` object
    */
   async subscribe(subscribe: SubscribeRequest): Promise<void> {
@@ -973,6 +1152,10 @@ export class FreenetWsApi {
       ClientRequestType.ContractRequest,
       new ContractRequestT(ContractRequestType.Subscribe, subscribe)
     ));
+    return this.awaitResponse(
+      this.pendingSubscribes,
+      instanceIdOf(subscribe.key)
+    );
   }
 
   /**

--- a/typescript/src/websocket-interface.ts
+++ b/typescript/src/websocket-interface.ts
@@ -1075,9 +1075,16 @@ export class FreenetWsApi {
    * byte-identical concurrent UPDATEs into a single transaction (its
    * `RequestRouter` dedup) and emits one result for both, so the extra callers
    * would wait out REQUEST_TIMEOUT_MS for an answer that is never coming twice.
-   * The cost is that two same-key requests with genuinely different outcomes
-   * both take the first outcome; with no id on the wire there is nothing better
-   * available, and asking one question twice deserves one answer.
+   * This is a trade, not a free win. Two same-key requests with genuinely
+   * different outcomes both take the first outcome, and what that costs depends
+   * on the operation. For a get it is benign — same contract, same answer
+   * either way. For an update it is what the node's own coalescing already
+   * does. For a **put it is a real mis-report**: two concurrent puts of
+   * different state to one key mean the second caller is told its put succeeded
+   * when in fact the first one's did. It is still the better trade — the wire
+   * carries no request id, so there is nothing to tell the two apart, and a 30s
+   * hang on a legitimate call is worse than an ambiguous success — but a reader
+   * changing this should know the cost is real and lands on put.
    */
   private takeMatching<T>(
     queue: PendingRequest<T>[],

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -282,6 +282,70 @@ describe("request/response correlation", () => {
     expect(b.key.encode()).toEqual(ENCODED_A);
   });
 
+  // Two concurrent requests for one contract are indistinguishable to the
+  // client: the wire carries no request id, and freenet-core drops its internal
+  // RequestId before `ClientEventsProxy::send`. So one answer has to settle all
+  // of them. Leaving the extras queued is not a safe default — the node
+  // coalesces byte-identical concurrent UPDATEs into a single transaction and
+  // emits one result for both, so a per-response settle would strand the second
+  // caller for the full REQUEST_TIMEOUT_MS.
+  test("one GetResponse settles every pending get for that key", async () => {
+    await connect();
+
+    const first = api.get(new GetRequest(new ContractKey(KEY_A), false));
+    const second = api.get(new GetRequest(new ContractKey(KEY_A), false));
+
+    send(getResponseFor(KEY_A, [0xaa])); // one response, two waiters
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a.state).toEqual([0xaa]);
+    expect(b.state).toEqual([0xaa]);
+  });
+
+  test("one error settles every pending request for that key", async () => {
+    await connect();
+
+    const first = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const second = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const other = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    send(errorResponse(`failed to get contract ${ENCODED_A}, reason: timeout`));
+
+    for (const settled of [await first, await second]) {
+      expect(settled).toBeInstanceOf(Error);
+      expect((settled as Error).message).toMatch(/timeout/);
+    }
+    // Scoping still holds: the other contract is untouched.
+    expect(await statusOf(other)).toEqual("pending");
+  });
+
+  test("one NotFound settles every pending get for that key", async () => {
+    await connect();
+
+    const first = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const second = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+
+    send(
+      contractResponse(
+        ContractResponseType.NotFound,
+        new NotFoundT(new ContractInstanceIdT(Array.from(KEY_A)))
+      )
+    );
+
+    for (const settled of [await first, await second]) {
+      expect(settled).toBeInstanceOf(Error);
+      expect((settled as Error).message).toEqual("Contract not found");
+    }
+  });
+
   test("a response for an unknown key is ignored, not mis-delivered", async () => {
     let handlerCalls = 0;
     await connect(makeHandler({ onContractGet: () => (handlerCalls += 1) }));

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Request/response correlation tests.
+ *
+ * The node does not guarantee that responses arrive in request order: each
+ * contract operation is driven by its own task and publishes its result to the
+ * per-client channel whenever it finishes (freenet-core
+ * `operations/get/op_ctx_task.rs` `start_client_get` spawns a detached task;
+ * results reach the socket writer through `result_router_tx` in completion
+ * order). A slow GET issued first therefore resolves after a cached GET issued
+ * second.
+ *
+ * These tests deliver responses out of order deliberately, so they pin the
+ * client-side contract regardless of what the node happens to do today.
+ */
+import * as flatbuffers from "flatbuffers";
+import base58 from "bs58";
+import { Server } from "mock-socket";
+import {
+  ContractResponseType,
+  ContractResponseT,
+  HostResponseType,
+  HostResponseT,
+  PutResponseT,
+  GetResponseT,
+  UpdateResponseT,
+  NotFoundT,
+  SubscribeResponseT,
+  ErrorT,
+} from "../src/host-response";
+import {
+  ContractContainer,
+  ContractKey,
+  DelegateResponse,
+  GetRequest,
+  GetResponse,
+  HostError,
+  FreenetWsApi,
+  PutRequest,
+  ResponseHandler,
+  StateUpdate,
+  SubscribeRequest,
+  UpdateData,
+  UpdateRequest,
+  WasmContractV1,
+} from "../src";
+import { ContractType } from "../src/common/contract-type";
+import { ContractCodeT } from "../src/common/contract-code";
+import { ContractKeyT } from "../src/common/contract-key";
+import { ContractInstanceIdT } from "../src/common/contract-instance-id";
+import { RelatedContractsT } from "../src/client-request/related-contracts";
+import { UpdateDataType } from "../src/common/update-data-type";
+
+const WS_URL = "ws://localhost:1240/contract/command/";
+
+/** Distinct, deterministic contract instance ids. */
+const KEY_A = new Uint8Array(32).fill(0xa1);
+const KEY_B = new Uint8Array(32).fill(0xb2);
+const KEY_C = new Uint8Array(32).fill(0xc3);
+const ENCODED_A = base58.encode(KEY_A);
+const ENCODED_B = base58.encode(KEY_B);
+
+function keyT(instance: Uint8Array): ContractKeyT {
+  return new ContractKeyT(new ContractInstanceIdT(Array.from(instance)), []);
+}
+
+function contractResponse(
+  type: ContractResponseType,
+  response:
+    | PutResponseT
+    | GetResponseT
+    | UpdateResponseT
+    | NotFoundT
+    | SubscribeResponseT
+): ArrayBuffer {
+  const contractResp = new ContractResponseT(type, response);
+  const hostResp = new HostResponseT(
+    HostResponseType.ContractResponse,
+    contractResp
+  );
+  const fbb = new flatbuffers.Builder(512);
+  fbb.finish(hostResp.pack(fbb));
+  return new Uint8Array(fbb.asUint8Array()).buffer;
+}
+
+function errorResponse(msg: string): ArrayBuffer {
+  const hostResp = new HostResponseT(HostResponseType.Error, new ErrorT(msg));
+  const fbb = new flatbuffers.Builder(256);
+  fbb.finish(hostResp.pack(fbb));
+  return new Uint8Array(fbb.asUint8Array()).buffer;
+}
+
+function getResponseFor(instance: Uint8Array, state: number[]): ArrayBuffer {
+  return contractResponse(
+    ContractResponseType.GetResponse,
+    new GetResponseT(keyT(instance), null, state)
+  );
+}
+
+function putResponseFor(instance: Uint8Array): ArrayBuffer {
+  return contractResponse(
+    ContractResponseType.PutResponse,
+    new PutResponseT(keyT(instance))
+  );
+}
+
+function subscribeResponseFor(
+  instance: Uint8Array,
+  subscribed: boolean
+): ArrayBuffer {
+  return contractResponse(
+    ContractResponseType.SubscribeResponse,
+    new SubscribeResponseT(keyT(instance), subscribed)
+  );
+}
+
+function makeHandler(overrides: Partial<ResponseHandler> = {}): ResponseHandler {
+  return {
+    onContractPut: () => {},
+    onContractGet: () => {},
+    onContractUpdate: () => {},
+    onContractUpdateNotification: () => {},
+    onContractNotFound: () => {},
+    onDelegateResponse: (_r: DelegateResponse) => {},
+    onErr: (_e: HostError) => {},
+    onOpen: () => {},
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a put whose container carries `containerKey`, defaulting to the key
+ * the host will echo back. The two differ in the mismatch test below.
+ */
+function putRequestFor(containerKey: Uint8Array): PutRequest {
+  const key = new ContractKey(containerKey);
+  const contract = new WasmContractV1(new ContractCodeT([1], [1]), [1], key);
+  const container = new ContractContainer(ContractType.WasmContractV1, contract);
+  return new PutRequest(container, [1, 2, 3], new RelatedContractsT([]));
+}
+
+function updateRequestFor(instance: Uint8Array): UpdateRequest {
+  return new UpdateRequest(
+    new ContractKey(instance),
+    new UpdateData(UpdateDataType.StateUpdate, new StateUpdate([1]))
+  );
+}
+
+/** Lets the websocket handshake complete before the test drives the server. */
+const settle = () => new Promise((r) => setTimeout(r, 100));
+
+/** Resolves to `"pending"` when `p` has not settled within `ms`. */
+async function statusOf<T>(
+  p: Promise<T>,
+  ms = 150
+): Promise<"pending" | T | Error> {
+  return Promise.race([
+    p.then(
+      (v) => v as T,
+      (e) => e as Error
+    ),
+    new Promise<"pending">((r) => setTimeout(() => r("pending"), ms)),
+  ]);
+}
+
+describe("request/response correlation", () => {
+  let server: Server;
+  let api: FreenetWsApi;
+
+  beforeEach(() => {
+    server = new Server(WS_URL);
+  });
+
+  afterEach(() => {
+    server.clients().forEach((c) => c.close());
+    server.close();
+  });
+
+  /** Connects an api that never auto-responds; each test drives the server. */
+  async function connect(
+    handler: ResponseHandler = makeHandler()
+  ): Promise<FreenetWsApi> {
+    api = new FreenetWsApi(new URL(WS_URL), handler);
+    await settle();
+    return api;
+  }
+
+  function send(data: ArrayBuffer): void {
+    server.clients().forEach((c) => c.send(data));
+  }
+
+  test("out-of-order GetResponses resolve their own request, not the oldest", async () => {
+    await connect();
+
+    const getA = api.get(new GetRequest(new ContractKey(KEY_A), false));
+    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    // B was requested second but its driver task finishes first.
+    send(getResponseFor(KEY_B, [0xbb]));
+    send(getResponseFor(KEY_A, [0xaa]));
+
+    const [a, b] = await Promise.all([getA, getB]);
+    expect(a.key.encode()).toEqual(ENCODED_A);
+    expect(a.state).toEqual([0xaa]);
+    expect(b.key.encode()).toEqual(ENCODED_B);
+    expect(b.state).toEqual([0xbb]);
+  });
+
+  test("out-of-order PutResponses resolve their own request", async () => {
+    await connect();
+
+    const putA = api.put(putRequestFor(KEY_A));
+    const putB = api.put(putRequestFor(KEY_B));
+
+    send(putResponseFor(KEY_B));
+    send(putResponseFor(KEY_A));
+
+    const [a, b] = await Promise.all([putA, putB]);
+    expect(a.key.encode()).toEqual(ENCODED_A);
+    expect(b.key.encode()).toEqual(ENCODED_B);
+  });
+
+  test("out-of-order UpdateResponses resolve their own request", async () => {
+    await connect();
+
+    const updA = api.update(updateRequestFor(KEY_A));
+    const updB = api.update(updateRequestFor(KEY_B));
+
+    send(
+      contractResponse(
+        ContractResponseType.UpdateResponse,
+        new UpdateResponseT(keyT(KEY_B), [0xbb])
+      )
+    );
+    send(
+      contractResponse(
+        ContractResponseType.UpdateResponse,
+        new UpdateResponseT(keyT(KEY_A), [0xaa])
+      )
+    );
+
+    const [a, b] = await Promise.all([updA, updB]);
+    expect(a.key.encode()).toEqual(ENCODED_A);
+    expect(a.summary).toEqual([0xaa]);
+    expect(b.key.encode()).toEqual(ENCODED_B);
+    expect(b.summary).toEqual([0xbb]);
+  });
+
+  test("NotFound rejects only the get for that contract", async () => {
+    await connect();
+
+    const getA = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    send(
+      contractResponse(
+        ContractResponseType.NotFound,
+        new NotFoundT(new ContractInstanceIdT(Array.from(KEY_B)))
+      )
+    );
+
+    await expect(getB).rejects.toThrow("Contract not found");
+    expect(await statusOf(getA)).toEqual("pending");
+
+    send(getResponseFor(KEY_A, [0xaa]));
+    const a = (await getA) as GetResponse;
+    expect(a.key.encode()).toEqual(ENCODED_A);
+  });
+
+  test("two concurrent gets for the same key both resolve", async () => {
+    await connect();
+
+    const first = api.get(new GetRequest(new ContractKey(KEY_A), false));
+    const second = api.get(new GetRequest(new ContractKey(KEY_A), false));
+
+    send(getResponseFor(KEY_A, [1]));
+    send(getResponseFor(KEY_A, [2]));
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a.key.encode()).toEqual(ENCODED_A);
+    expect(b.key.encode()).toEqual(ENCODED_A);
+  });
+
+  test("a response for an unknown key is ignored, not mis-delivered", async () => {
+    let handlerCalls = 0;
+    await connect(makeHandler({ onContractGet: () => (handlerCalls += 1) }));
+
+    const getA = api.get(new GetRequest(new ContractKey(KEY_A), false));
+
+    // A stray response for a contract nothing is waiting on.
+    send(getResponseFor(KEY_C, [0xcc]));
+    expect(await statusOf(getA)).toEqual("pending");
+
+    send(getResponseFor(KEY_A, [0xaa]));
+    const a = await getA;
+    expect(a.key.encode()).toEqual(ENCODED_A);
+    // The legacy callback API still sees both responses.
+    expect(handlerCalls).toBe(2);
+  });
+
+  test("a lone put still resolves when the host's key differs from the container's", async () => {
+    await connect();
+
+    // The node recomputes a put's key from code + parameters
+    // (`ContractKey::from_params_and_code`), so the container key the client
+    // supplied is advisory. With a single put in flight the answer is
+    // unambiguous and must still be delivered.
+    const put = api.put(putRequestFor(KEY_A));
+    send(putResponseFor(KEY_C));
+
+    const response = await put;
+    expect(response.key.encode()).toEqual(base58.encode(KEY_C));
+  });
+
+  test("subscribe() resolves only once the host confirms", async () => {
+    await connect();
+
+    const sub = api.subscribe(new SubscribeRequest(new ContractKey(KEY_A)));
+    expect(await statusOf(sub)).toEqual("pending");
+
+    send(subscribeResponseFor(KEY_A, true));
+    await expect(sub).resolves.toBeUndefined();
+  });
+
+  test("subscribe() rejects when the host refuses the subscription", async () => {
+    await connect();
+
+    const sub = api.subscribe(new SubscribeRequest(new ContractKey(KEY_A)));
+    send(subscribeResponseFor(KEY_A, false));
+    await expect(sub).rejects.toThrow(/not subscribed/i);
+  });
+
+  test("out-of-order SubscribeResponses resolve their own request", async () => {
+    await connect();
+
+    const subA = api.subscribe(new SubscribeRequest(new ContractKey(KEY_A)));
+    const subB = api
+      .subscribe(new SubscribeRequest(new ContractKey(KEY_B)))
+      .catch((e: Error) => e);
+
+    // B is refused, A succeeds, and B's answer arrives first.
+    send(subscribeResponseFor(KEY_B, false));
+    send(subscribeResponseFor(KEY_A, true));
+
+    await expect(subA).resolves.toBeUndefined();
+    expect(await subB).toBeInstanceOf(Error);
+  });
+
+  test("an error naming one contract does not reject requests for others", async () => {
+    await connect();
+
+    const getA = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    // Mirrors freenet-stdlib's `ContractError::Get` Display, which renders the
+    // key as base58 of the instance id.
+    send(errorResponse(`failed to get contract ${ENCODED_B}, reason: timeout`));
+
+    const b = await getB.catch((e: Error) => e);
+    expect(b).toBeInstanceOf(Error);
+    expect((b as Error).message).toMatch(/timeout/);
+    expect(await statusOf(getA)).toEqual("pending");
+  });
+
+  test("an error naming no known contract still fails every pending request", async () => {
+    await connect();
+
+    const getA = api.get(new GetRequest(new ContractKey(KEY_A), false));
+    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    send(errorResponse("internal node error"));
+
+    await expect(getA).rejects.toThrow("internal node error");
+    await expect(getB).rejects.toThrow("internal node error");
+  });
+
+  test("connection close still rejects every pending request", async () => {
+    await connect();
+
+    const getA = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const sub = api
+      .subscribe(new SubscribeRequest(new ContractKey(KEY_B)))
+      .catch((e: Error) => e);
+
+    server.clients().forEach((c) => c.close());
+
+    expect(await getA).toBeInstanceOf(Error);
+    expect(((await getA) as Error).message).toMatch(/Connection closed/);
+    expect(await sub).toBeInstanceOf(Error);
+  });
+});

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -591,7 +591,10 @@ describe("request/response correlation", () => {
     expect(await statusOf(putB)).toEqual("pending");
   });
 
-  test("a timed-out put fences a later recomputed-key answer", async () => {
+  // Named for the mechanism it actually drives: this reaches the fence through
+  // rejectAllPending, not through the timeout. The timeout path has its own test
+  // in the "request timeout" block below.
+  test("a connection-wide error fences a later recomputed-key answer", async () => {
     await connect();
 
     const putA = api.put(putRequestFor(KEY_A)).catch((e: Error) => e);

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -480,6 +480,57 @@ describe("request/response correlation", () => {
     expect(await statusOf(getB)).toEqual("pending");
   });
 
+  test("an error naming one contract fails every operation on it", async () => {
+    await connect();
+
+    // Pins the imprecision `rejectForError` documents as accepted: the host
+    // says which contract failed, never which operation, so a get and an update
+    // on that contract both fail. Locking it in means a future change cannot
+    // quietly widen it past one contract.
+    const getA = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const updA = api.update(updateRequestFor(KEY_A)).catch((e: Error) => e);
+    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    send(errorResponse(`failed to get contract ${ENCODED_A}, reason: timeout`));
+
+    for (const settled of [await getA, await updA]) {
+      expect(settled).toBeInstanceOf(Error);
+      expect((settled as Error).message).toMatch(/timeout/);
+    }
+    expect(await statusOf(getB)).toEqual("pending");
+  });
+
+  test("a key that is a base58 prefix of another is not mistaken for it", async () => {
+    await connect();
+
+    // Base58 renders each leading zero byte as a leading '1', so ids with a long
+    // run of leading zeros give short '1'-heavy strings and one key's whole
+    // encoding can be a literal prefix of another's. A raw substring test would
+    // read the error below as naming SHORT and fail the wrong request.
+    const short = new Uint8Array(32);
+    short[31] = 1; // -> "1"*31 + "2"
+    const long = new Uint8Array(32);
+    long[31] = 58; // -> "1"*31 + "21"
+    expect(base58.encode(long).startsWith(base58.encode(short))).toBe(true);
+
+    // Queued first, so a substring match would find it before the real target.
+    const getShort = api.get(new GetRequest(new ContractKey(short), false));
+    const getLong = api
+      .get(new GetRequest(new ContractKey(long), false))
+      .catch((e: Error) => e);
+
+    send(
+      errorResponse(
+        `failed to get contract ${base58.encode(long)}, reason: timeout`
+      )
+    );
+
+    expect(await getLong).toBeInstanceOf(Error);
+    expect(await statusOf(getShort)).toEqual("pending");
+  });
+
   test("an error naming no known contract still fails every pending request", async () => {
     await connect();
 
@@ -501,6 +552,24 @@ describe("request/response correlation", () => {
     }
   });
 
+  test("a connection-wide error also fences the lone-put fall-back", async () => {
+    await connect();
+
+    // Same hazard as the timeout path, reached without fake timers: put A is
+    // failed by an untargeted error, the caller retries as put B, and A's late
+    // answer must not be handed to B.
+    const putA = api.put(putRequestFor(KEY_A)).catch((e: Error) => e);
+    send(errorResponse("internal node error"));
+    expect(await putA).toBeInstanceOf(Error);
+
+    const putB = api.put(putRequestFor(KEY_B));
+    send(putResponseFor(KEY_A)); // A's answer, arriving after A gave up
+    expect(await statusOf(putB)).toEqual("pending");
+
+    send(putResponseFor(KEY_B));
+    expect((await putB).key.encode()).toEqual(ENCODED_B);
+  });
+
   test("connection close still rejects every pending request", async () => {
     await connect();
 
@@ -516,5 +585,55 @@ describe("request/response correlation", () => {
     expect(await getA).toBeInstanceOf(Error);
     expect(((await getA) as Error).message).toMatch(/Connection closed/);
     expect(await sub).toBeInstanceOf(Error);
+  });
+});
+
+/**
+ * Drives the REQUEST_TIMEOUT_MS path, which nothing else in the suite exercises.
+ *
+ * mock-socket cannot complete a handshake under fake timers (the socket stays in
+ * CONNECTING), so the connection is established on real timers first and the
+ * clock is only faked around the timeout itself.
+ */
+describe("request timeout", () => {
+  const TIMEOUT_WS_URL = "ws://localhost:1241/contract/command/";
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server(TIMEOUT_WS_URL);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    server.clients().forEach((c) => c.close());
+    server.close();
+  });
+
+  test("a late answer to a timed-out put does not hijack the next put", async () => {
+    const api = new FreenetWsApi(new URL(TIMEOUT_WS_URL), makeHandler());
+    await settle();
+
+    jest.useFakeTimers();
+    // Queued under the fake clock, so its REQUEST_TIMEOUT_MS timer is fake too.
+    const putA = api.put(putRequestFor(KEY_A)).catch((e: Error) => e);
+    jest.advanceTimersByTime(31_000);
+    const timedOut = await putA;
+    expect(timedOut).toBeInstanceOf(Error);
+    expect((timedOut as Error).message).toEqual("Request timeout");
+
+    // The caller retries. B is now the sole pending put, which is exactly the
+    // condition the lone-put fall-back keys on.
+    const putB = api.put(putRequestFor(KEY_B));
+    jest.useRealTimers();
+
+    // A's answer finally arrives. Without the abandoned-key fence it has no
+    // exact match, the queue holds exactly one put, and B resolves with A's
+    // response — the mis-delivery this whole change exists to remove.
+    server.clients().forEach((c) => c.send(putResponseFor(KEY_A)));
+    expect(await statusOf(putB)).toEqual("pending");
+
+    // B still gets its own answer.
+    server.clients().forEach((c) => c.send(putResponseFor(KEY_B)));
+    expect((await putB).key.encode()).toEqual(ENCODED_B);
   });
 });

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -363,6 +363,33 @@ describe("request/response correlation", () => {
     expect(handlerCalls).toBe(2);
   });
 
+  test("a request with no usable key fails at send, never reaching the queue", async () => {
+    await connect();
+
+    // Pins the assumption `takeMatching` relies on for having no fall-back tier
+    // for uncorrelatable requests: `key` is `(required)` on Get, Update,
+    // Subscribe and WasmContractV1, so flatbuffers refuses to pack a request
+    // without one and `sendRequest` throws before anything is queued. If the
+    // schema ever loses `required`, this goes green-to-red and the reader knows
+    // the no-fall-back assumption needs revisiting.
+    const keyless = api.update(
+      new UpdateRequest(
+        null,
+        new UpdateData(UpdateDataType.StateUpdate, new StateUpdate([1]))
+      )
+    );
+    // Asserting the reason, not merely that something threw: a bare
+    // `.rejects.toThrow()` would stay green if the call started failing for an
+    // unrelated cause, and the pin would quietly stop testing the schema.
+    await expect(keyless).rejects.toThrow(/FlatBuffers: field \d+ must be set/);
+
+    // Nothing was queued, so a later response for another contract is not
+    // absorbed by a stranded entry.
+    const getA = api.get(new GetRequest(new ContractKey(KEY_A), false));
+    send(getResponseFor(KEY_A, [0xaa]));
+    expect((await getA).state).toEqual([0xaa]);
+  });
+
   test("a lone put still resolves when the host's key differs from the container's", async () => {
     await connect();
 

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -365,16 +365,49 @@ describe("request/response correlation", () => {
     expect(await statusOf(getA)).toEqual("pending");
   });
 
+  test("a subscriber-limit error rejects only that subscribe", async () => {
+    await connect();
+
+    const subA = api
+      .subscribe(new SubscribeRequest(new ContractKey(KEY_A)))
+      .catch((e: Error) => e);
+    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+
+    // freenet-core builds this error with a synthetic ContractKey whose code
+    // hash is zeroed (`subscriber_limit_error` in
+    // contract/executor/runtime.rs). Correlation keys on the instance id, which
+    // is the real one, so the synthetic code hash does not defeat the match.
+    send(
+      errorResponse(
+        `failed to subscribe for contract ${ENCODED_A}, reason: too many subscribers`
+      )
+    );
+
+    const a = await subA;
+    expect(a).toBeInstanceOf(Error);
+    expect((a as Error).message).toMatch(/too many subscribers/);
+    expect(await statusOf(getB)).toEqual("pending");
+  });
+
   test("an error naming no known contract still fails every pending request", async () => {
     await connect();
 
-    const getA = api.get(new GetRequest(new ContractKey(KEY_A), false));
-    const getB = api.get(new GetRequest(new ContractKey(KEY_B), false));
+    // Settled through `.catch` rather than left bare: if this assertion ever
+    // fails, an un-awaited rejection would surface inside a later test's
+    // teardown and report the failure against the wrong test.
+    const getA = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e: Error) => e);
+    const getB = api
+      .get(new GetRequest(new ContractKey(KEY_B), false))
+      .catch((e: Error) => e);
 
     send(errorResponse("internal node error"));
 
-    await expect(getA).rejects.toThrow("internal node error");
-    await expect(getB).rejects.toThrow("internal node error");
+    for (const settled of [await getA, await getB]) {
+      expect(settled).toBeInstanceOf(Error);
+      expect((settled as Error).message).toEqual("internal node error");
+    }
   });
 
   test("connection close still rejects every pending request", async () => {

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -570,6 +570,39 @@ describe("request/response correlation", () => {
     expect((await putB).key.encode()).toEqual(ENCODED_B);
   });
 
+  // The two tests above answer with the same key the departed put was queued
+  // under. That is the easy half. The fall-back exists precisely because a put's
+  // answer can arrive under a key the client never sent — the host recomputes it
+  // — so the fence has to hold when the late answer bears an unfamiliar key too.
+  // A fence that compared contract keys would pass the two above and fail these.
+  test("a late answer under a recomputed key does not hijack the next put", async () => {
+    await connect();
+
+    const putA = api.put(putRequestFor(KEY_A)).catch((e: Error) => e);
+    // Targeted error: A departs through the exact-match branch of
+    // rejectForError, which is a third departure path.
+    send(errorResponse(`put error for contract ${ENCODED_A}, reason: refused`));
+    expect(await putA).toBeInstanceOf(Error);
+
+    const putB = api.put(putRequestFor(KEY_B));
+    // A's real answer, under the key the host computed — never a container key,
+    // so nothing the client could have recorded from A's request would match it.
+    send(putResponseFor(KEY_C));
+    expect(await statusOf(putB)).toEqual("pending");
+  });
+
+  test("a timed-out put fences a later recomputed-key answer", async () => {
+    await connect();
+
+    const putA = api.put(putRequestFor(KEY_A)).catch((e: Error) => e);
+    send(errorResponse("internal node error"));
+    expect(await putA).toBeInstanceOf(Error);
+
+    const putB = api.put(putRequestFor(KEY_B));
+    send(putResponseFor(KEY_C)); // divergent key, unrelated to either container
+    expect(await statusOf(putB)).toEqual("pending");
+  });
+
   test("connection close still rejects every pending request", async () => {
     await connect();
 

--- a/typescript/tests/delegates-and-responses.test.ts
+++ b/typescript/tests/delegates-and-responses.test.ts
@@ -427,6 +427,13 @@ describe("Subscribe with SubscribeResponse", () => {
               if (cr.contractRequest && cr.contractRequest.summary) {
                 receivedSummary = cr.contractRequest.summary.length > 0;
               }
+              // subscribe() resolves on the host's confirmation, so answer it.
+              socket.send(
+                buildContractResponse(
+                  ContractResponseType.SubscribeResponse,
+                  new SubscribeResponseT(makeKeyT(), true)
+                )
+              );
             }
           }
         } catch (_) {}

--- a/typescript/tests/websocket-interface.test.ts
+++ b/typescript/tests/websocket-interface.test.ts
@@ -833,6 +833,13 @@ describe("Subscribe and Disconnect requests", () => {
             const cr = req.clientRequest as any;
             if (cr.contractRequestType === CRType.Subscribe) {
               receivedSubscribe = true;
+              // subscribe() resolves on the host's confirmation, so answer it.
+              socket.send(
+                buildContractResponse(
+                  ContractResponseType.SubscribeResponse,
+                  new SubscribeResponseT(makeKeyT(), true)
+                )
+              );
             }
           }
         } catch (_) {}


### PR DESCRIPTION
## Problem

The TypeScript websocket client resolved the **oldest** pending request of a type with whatever response arrived, with no correlation at all:

```ts
private resolveNext<T>(queue: PendingRequest<T>[], value: T): void {
  const pending = queue.shift();   // <- whoever asked first gets whatever came back
```

Two concurrent `get()`s for different contracts whose answers came back out of order therefore resolved into **each other's** promises. Silent data mixing: no error, no warning, the caller just gets another contract's state.

This is reachable in production, not a theoretical ordering nit. In freenet-core each contract operation is driven by its own detached task (`operations/get/op_ctx_task.rs` `start_client_get`, and PUT the same way) and publishes its result through `result_router_tx` whenever it finishes. The socket writer drains that per-client channel FIFO — but FIFO of **completion** order, not request order. A cold GET issued first and a cached GET issued second come back second-then-first. Confirmed against `crates/core/src/client_events.rs:315` (`FuturesUnordered`) and `client_events/websocket.rs:466`.

Two related defects in the same area:

- **`subscribe()` never rejected.** It returned a `Promise<void>` that resolved on *send*; there was no `pendingSubscribes` queue at all. A refused subscription (the node's per-client subscriber cap, for instance) left the awaited promise silently resolved. The doc comment already described it as promise-based; it wasn't.
- **Any host error failed every in-flight request.** `rejectAllPending` rejected every pending get, put and update across all contracts, whatever the error was about.

## Approach

**Correlate on the contract key.** There is no request id in the contract-op protocol — the single `request_id` in stdlib's `client_events.rs` is delegate-only, and freenet-core's internal `RequestId` never crosses the wire. But every `ContractResponse` variant carries `key: ContractKey` (or `instance_id` for `NotFound`), so the identifying information exists and was simply being discarded. Requests now record the base58 instance id they expect back, and `takeMatching` resolves against it.

The match order, with the fall-backs that keep the edges sane:

1. **Every** request awaiting this exact key — see below.
2. For puts only, the lone in-flight request — **provided the key is not one we have abandoned**. The node **recomputes** a put's key from code and parameters (`ContractKey::from_params_and_code`), so the container key the client supplied is advisory and may not match what comes back. With exactly one put in flight the answer is unambiguous and is still delivered; with two or more it would be a guess, and a guess is the defect being fixed. The abandoned-key fence is explained below.
3. Otherwise nothing — an unmatched response is dropped rather than mis-delivered. The `ResponseHandler` callbacks still fire for it, so the legacy API is unchanged and nothing leaks; requests keep waiting for their own answer or time out.

**Why tier 1 settles *all* same-key requests, not just the oldest.** Two concurrent requests for one contract are indistinguishable to the client: the wire carries no request id, and freenet-core drops its internal `RequestId` before `ClientEventsProxy::send` (`client_events.rs:368`). Settling one and leaving the rest queued is not a safe default — the node coalesces byte-identical concurrent UPDATEs into a single transaction via its `RequestRouter` dedup (`client_events.rs:711-719`, `request_router.rs:304-388`) and emits **one** result for both, so the extra callers would wait out the full 30s timeout for an answer that never comes twice. This is a trade, not a free win, and the cost lands unevenly. Two same-key requests with genuinely different outcomes both take the first outcome. For a **get** that is benign — same contract, same answer either way. For an **update** it is what the node's coalescing already does. For a **put** it is a real if narrow mis-report: two concurrent puts of different state to one key mean the second caller is told its put succeeded when in fact the first one's did. It remains the better trade — the wire carries no request id, so there is nothing to tell the two apart, and a 30s hang on a legitimate call is worse than an ambiguous success — but it is a trade, and the JSDoc says so at the code.

**Fencing the lone-put fall-back against late answers.** On its own, `queue.length === 1` cannot tell "the key differs because the host recomputed it" — the case the tier exists for — from "the key differs because this answer belongs to a request that is already gone". Put A times out and is spliced out, the caller retries as put B, A's late answer arrives, no exact match, one put in the queue, and **B resolves with contract A's response** — while B's real answer is later dropped against an empty queue, so the caller never learns whether B succeeded. The conditions that cause the timeout (host overloaded, jitter) are the same ones that make a late arrival likely.

The fence deliberately does **not** compare contract keys. A first attempt did, remembering the keys of abandoned requests — and it could not work, because the key a put is *queued* under is the client's container key while the key its answer *arrives* under is the host's recomputed one, and those differing is the entire reason this tier exists. Comparing them closes the hazard only when they happen to agree, which is exactly when an exact match would have handled it anyway. A count of departures since the survivor was queued does not close it either: in the sequence above A departs *before* B is queued, so the delta is zero and the late answer still gets through.

The question answerable without a key is "has any put given up without an answer at all", so the fence is a single sticky flag. Once set, a divergent-key put times out rather than resolving — the safe direction, a late answer instead of a wrong one. Every way a put can leave the queue was audited rather than assumed: the timeout splice, `rejectAllPending`, and the exact-match branch of `rejectForError` (which attributes a failure by finding the key in a message, and so does not stop the real answer arriving). All three disarm; `NotFound` and a refused `SubscribeResponse` do not touch puts.

There is no fall-back tier for a request whose key could not be read, because none can exist: `key` is `(required)` on `Get`, `Update`, `Subscribe` and `WasmContractV1` (`client_request.fbs`, `common.fbs`), so `sendRequest` throws `FlatBuffers: field 4 must be set` while packing, before anything is queued. A test pins that, asserting the reason rather than merely that something threw.

**`subscribe()`** now awaits a `pendingSubscribes` entry: resolves on `SubscribeResponse { subscribed: true }`, rejects on `subscribed: false`, on an error naming the contract, on connection close, or on `REQUEST_TIMEOUT_MS`. This is a **behavioural change** for callers who `await subscribe()` — it previously resolved immediately and could never reject.

**Errors** are narrowed to the requests they name. The wire `Error` carries only a message string (`host_response.fbs`), so there is nothing to key on directly — but stdlib renders the contract key into the message (`ContractError`'s `Display`, base58 of the instance id). Rather than parse the node's sentence, this scans the message for the keys of the requests *we* are waiting on, so a wording change degrades to the fall-back instead of mis-attributing a failure. The scan is boundary-aware, not a raw substring test: base58 renders each leading zero byte of an instance id as a leading `'1'`, so ids with a long run of leading zeros give short `'1'`-heavy strings and one key's whole encoding can be a literal prefix of another's — which would make an error naming one contract also fail a request for the other. When no pending key appears, the error can't be attributed and may be connection-wide, so everything is failed as before — a genuinely fatal error must not leave callers hanging for 30s.

Two things worth calling out about the error path:

- The subscriber-limit error the node builds with a **synthetic key (zeroed `CodeHash`)** still matches, because correlation keys on the *instance* id and that half is real. There is a test pinning this. It does not depend on the separate node-side fix.
- Residual imprecision, deliberately accepted: every in-flight request naming that contract fails, across operations (a get and an update on it both fail) and across duplicates (two concurrent gets on it both fail). The host says neither which operation failed nor which of two identical requests. Bounding the blast radius to one contract is the win, and failing all of them beats stranding the ones that are not the oldest.

## Testing

New `typescript/tests/correlation.test.ts` (24 tests) drives the mock server directly so responses can be delivered out of order regardless of what the node does today.

Proven failing first: **10 of 13** failed against `origin/main` before any source change, including the core one —

```
● out-of-order GetResponses resolve their own request, not the oldest
  Expected: "Bswb3UyeD1pUTaGiE6WvqwFpJZsQSEY1xhJePCDTHdvp"   (contract A)
  Received: "D2ZcUbtpG5sKq7XLeB4YnpNnTGSptKCxTddoNeydzJQq"   (contract B)
```

`get(A)` resolving with contract B's key **and** B's state is the data mixing, reproduced.

The 3 that passed pre-fix are the ones asserting behaviour that must *not* regress (same-key concurrency, a lone put, a connection-wide error failing everything). Nine tests were added afterwards during review, each proven failing before its fix where it fixes something: the subscriber-limit error shape, the three same-key settle-all cases, the schema pin, the four lone-put fence cases (two where the late answer bears the departed request's own key, two where it bears a key the client never sent), and the base58 prefix collision. The ninth is a characterization pin for the accepted cross-op imprecision, and correctly passes before and after — it exists so a future change cannot silently widen that behaviour.

The lone-put hijack reproduced concretely: with the fence removed, put B resolves carrying contract A's key.

Coverage: out-of-order get/put/update/subscribe; a late answer to a timed-out put not hijacking the next put (driven with `jest.useFakeTimers()` — nothing previously exercised `REQUEST_TIMEOUT_MS` at all) and the same hazard reached through a connection-wide error; a base58 prefix collision not being mistaken for a key match; a get and an update on one contract both failing on one error naming it; `NotFound` rejecting only its own get; two concurrent gets for the same key; one response / one error / one `NotFound` each settling *every* pending request for that key; a stray response for an unrequested key being ignored while the callback API still sees it; a lone put with a mismatched container key; a keyless request failing at pack time rather than queueing; subscribe resolve/reject; error scoping including the subscriber-limit shape; connection close still failing everything.

Mutation-tested to confirm the tests are real gates, not decoration:

| Mutation | Tests killed |
|---|---|
| `takeMatching` ignores the key (pure FIFO) | 7 |
| `takeMatching` settles only the oldest same-key request | 3 |
| Drop the lone-put fall-back | 1 |
| Drop the "no key matched, fail everything" fall-back | 1 (+1 cascade) |
| Lone-put fall-back always armed | 4 |
| Timeout no longer disarms the fall-back | 1 |
| `rejectAllPending` no longer disarms it | 2 |
| `rejectMatching` no longer disarms it | 1 |
| Raw substring instead of a boundary-aware key match | 1 |

Two pre-existing tests needed updating: `subscribe() sends a valid Subscribe ClientRequest` and `subscribe with summary sends correct data` both `await api.subscribe(...)` against a mock server that never answered. They assert what goes out on the wire, so the server now sends back the `SubscribeResponse` the client waits for; their assertions are unchanged.

`npm run build` and `npm test` clean: **76 passed, 4 suites**.

## Not fixed here

- **`NotFound` does not reject a pending `subscribe()`** for that contract, matching the previous behaviour (it only ever touched gets). The node answers a subscribe for a missing contract with an error naming the contract, which `rejectForError` attributes, so the caller still fails fast. Recorded as a comment at the `NotFound` case, not only here.
- Nothing on the Rust side was touched.

A CHANGELOG entry is included under `[Unreleased]`, in a TypeScript-SDK section. The npm package is versioned separately from the Rust crate and needs a **minor** bump for this — 0.3.0 -> 0.4.0, not 0.3.1 — because `subscribe()`'s semantics change for existing callers.

[AI-assisted - Claude]
