### PR TITLE
chore(typescript)!: release 0.4.0 and pin the same-key correlation residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## [Unreleased]
 
-### TypeScript SDK — Breaking (npm package `@freenetorg/freenet-stdlib`; next release must be 0.4.0, not a patch)
+### TypeScript SDK 0.4.0 — Breaking (npm package `@freenetorg/freenet-stdlib`)
 
 The npm package is versioned separately from the Rust crate. This release
 changes runtime behavior for existing callers, so on a 0.x line it takes a
 minor bump: **0.3.0 -> 0.4.0**, not 0.3.1.
+
+Upgrading from npm: 0.3.0 and earlier matched responses to requests by *arrival
+order alone*, with no correlation of any kind, so concurrent requests for
+different contracts could resolve into each other's promises. That is what this
+release fixes. Applications that serialised their requests to work around it can
+stop doing so **for requests on different contracts**; see "Known limitation"
+below before relaxing it for concurrent requests on the *same* contract.
 
 - **Host responses are now correlated to requests by contract key.**
   `FreenetWsApi` previously resolved the *oldest* pending request of a type
@@ -45,6 +52,44 @@ minor bump: **0.3.0 -> 0.4.0**, not 0.3.1.
   Errors are now scoped to the requests whose contract key the error message
   names. An error naming no pending contract still fails everything, since it
   may be connection-wide and must not leave callers waiting out the timeout.
+
+#### Known limitation: two requests for the SAME contract key
+
+Correlation is by contract key, because the key is the only identifying field a
+`ContractResponse` carries. Two requests for the *same* key are therefore
+indistinguishable, and one case remains open, reported as
+[#96](https://github.com/freenet/freenet-stdlib/issues/96):
+
+Giving up on a request locally does not stop the node working on it — the SDK
+sends nothing to cancel the operation — so a request that hit
+`REQUEST_TIMEOUT_MS` can still be answered afterwards. If the caller has retried
+the same contract by then, that late answer matches the retry exactly and
+settles it. The retry resolves with a result fetched for a request its caller
+already abandoned, and its own answer is later dropped against an empty queue.
+Mostly this means staler state for the right contract, but not always: a retry
+issued with `fetchContract: true` can be settled by an earlier response that
+carries no contract.
+
+**This release does not fix that, deliberately.** A client-side fence was
+attempted and withdrawn: with no request id on the wire, the SDK cannot tell a
+late answer from the retry's own answer, so any rule that drops "the next
+response for this key" is as likely to drop the retry's answer as the ghost's.
+Doing so hangs that retry until its own timeout, which mints another
+indistinguishable case — a self-sustaining chain of spurious timeouts against a
+contract the node is serving correctly. That is a worse failure than the
+mis-delivery it was meant to prevent. The evidence is on
+[#105](https://github.com/freenet/freenet-stdlib/pull/105).
+
+The real fix is a client-generated request id echoed in every terminal response,
+which makes correlation exact and this whole class of problem unreachable. That
+is a wire-protocol change spanning freenet-core, tracked in
+[#106](https://github.com/freenet/freenet-stdlib/issues/106).
+
+**Until then**, an application that issues concurrent requests for the same
+contract key, or retries one after a timeout, should treat a response as
+"an answer for this contract" rather than "the answer to this call": re-check
+whatever the result is used for, and prefer idempotent retries. Requests for
+*different* contracts are correlated correctly and need no such care.
 
 ### Breaking (next release must be 0.9.0, not a patch)
 - **`DelegateRequest::RegisterDelegateWithPredecessors`** removed (added in

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freenetorg/freenet-stdlib",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Freenet standard library and utils",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/typescript/tests/correlation.test.ts
+++ b/typescript/tests/correlation.test.ts
@@ -673,3 +673,96 @@ describe("request timeout", () => {
     expect((await putB).key.encode()).toEqual(ENCODED_B);
   });
 });
+
+/**
+ * The residual that key-based correlation cannot close, pinned as a KNOWN
+ * LIMITATION rather than as desired behaviour.
+ *
+ * Two requests for the same contract key are identical on the wire — the key is
+ * the only identifying field a `ContractResponse` carries — so a late answer to
+ * a request the caller has already abandoned matches a retry for that key
+ * exactly. Reported as issue 96.
+ *
+ * A client-side fence for this was attempted and withdrawn (PR 105). With no
+ * request id, "drop the next response for this key" cannot tell the ghost's
+ * answer from the retry's own, and dropping the retry's answer hangs it until
+ * its own timeout — which mints another indistinguishable case, chaining
+ * spurious timeouts against a contract the node is serving correctly. That is
+ * worse than the mis-delivery it removes.
+ *
+ * These tests therefore assert what the SDK ACTUALLY DOES today. They are
+ * expected to be inverted, not deleted, by the wire-level request id that fixes
+ * this properly (issue 106).
+ */
+describe("known limitation: same-key requests are indistinguishable", () => {
+  const RESIDUAL_WS_URL = "ws://localhost:1243/contract/command/";
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server(RESIDUAL_WS_URL);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    server.clients().forEach((c) => c.close());
+    server.close();
+  });
+
+  async function connectResidual(): Promise<FreenetWsApi> {
+    const api = new FreenetWsApi(new URL(RESIDUAL_WS_URL), makeHandler());
+    await settle();
+    return api;
+  }
+
+  test("a late answer to a timed-out get settles a retry for the same key", async () => {
+    const api = await connectResidual();
+
+    jest.useFakeTimers();
+    const abandoned = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e) => e);
+    jest.advanceTimersByTime(31_000);
+    expect(((await abandoned) as Error).message).toEqual("Request timeout");
+
+    // The node is still working on the abandoned request; nothing cancelled it.
+    const retry = api.get(new GetRequest(new ContractKey(KEY_A), false));
+    jest.useRealTimers();
+
+    // The abandoned request's answer arrives. It matches the retry's key
+    // exactly, and nothing on the wire distinguishes the two requests.
+    server
+      .clients()
+      .forEach((c) => c.send(getResponseFor(KEY_A, [0x01])));
+
+    // KNOWN LIMITATION: the retry settles with the abandoned request's answer.
+    // Invert this assertion once responses carry a request id.
+    expect((await retry).state).toEqual([0x01]);
+  });
+
+  test("a response for a DIFFERENT key never settles the wrong request", async () => {
+    const api = await connectResidual();
+
+    jest.useFakeTimers();
+    const abandoned = api
+      .get(new GetRequest(new ContractKey(KEY_A), false))
+      .catch((e) => e);
+    jest.advanceTimersByTime(31_000);
+    await abandoned;
+
+    const other = api.get(new GetRequest(new ContractKey(KEY_B), false));
+    jest.useRealTimers();
+
+    // The bound that DOES hold: the abandoned request's answer cannot reach a
+    // request for another contract. This is the half #94 fixed and the half
+    // that carried the real user-visible harm.
+    server
+      .clients()
+      .forEach((c) => c.send(getResponseFor(KEY_A, [0x01])));
+    expect(await statusOf(other)).toEqual("pending");
+
+    server
+      .clients()
+      .forEach((c) => c.send(getResponseFor(KEY_B, [0x02])));
+    expect((await other).state).toEqual([0x02]);
+  });
+});


### PR DESCRIPTION
## What this does

1. **Releases 0.4.0.** [#94](https://github.com/freenet/freenet-stdlib/pull/94) has been merged and unreleased since 2026-08-22. npm's published latest is still **0.3.0 from 2026-06-27**, which matches responses to requests by *arrival order alone* — so every npm consumer today is running the uncorrelated behaviour, including the cross-contract mis-delivery that carried the real harm. Getting that out is the substance of this PR.
2. **Pins the residual #94 does not fix**, as a documented limitation with tests, plus a tracking issue for the real fix.

## History of this PR — a fix was attempted and withdrawn

This PR originally added a client-side fence for the same-key case in #96: when a request was abandoned without an answer, record a "debt" for its key, and let the next response for that key settle the debt rather than a request queued afterwards.

**It was withdrawn as unsound.** Review (four Claude lenses plus Codex) converged on the same defect, and I reproduced it before acting:

The SDK cannot tell a late answer from the retry's own answer. They are the same message shape for the same key. Whichever arrives first is absorbed — and the likely ordering is the unhelpful one, because the abandoned request timed out precisely because it was slow, while the retry may be served quickly. So the fence drops the retry's own answer, the retry hangs until its own 30s timeout, and that mints another indistinguishable case:

```
t=0   get(K) sent, slow
t=30  times out            -> debt(K)
t=31  caller retries get(K)
t=35  the RETRY's own answer arrives -> absorbed by debt(K), dropped
t=61  retry times out      -> debt(K) again ... repeats
```

A self-sustaining chain of spurious timeouts against a contract the node is serving correctly — worse than the mis-delivery it removes. The 240s expiry I added as the safety valve never fires, because each debt is spent long before it can expire. The test I wrote for that valve covered the case where *no* response arrives, which is exactly the case that cannot occur in this loop.

Two facts from freenet-core make any such fence unsafe in principle, not just in this shape:

- The session actor delivers **at most one `HostResponse` per (transaction, client)** — `handle_result_delivery` removes the transaction entry on first delivery. So a host `Error` *is* terminal; a fence assuming a success can still follow it records a claim that will never be paid.
- An operation can die emitting no client result at all (result-router channel dropped under saturation, `pending_results` LRU eviction). "Eventually answered" is not guaranteed.

So a debt is an unbacked claim on a response that may never come. The withdrawn commit is `ec9be1f` if anyone wants to read it.

## What ships instead

The CHANGELOG gains a **Known limitation** section stating the residual plainly, including the case that is not merely "staler state": a retry issued with `fetchContract: true` can be settled by an earlier response carrying no contract.

Two tests in `tests/correlation.test.ts`:

- `a late answer to a timed-out get settles a retry for the same key` — asserts the residual **as it actually behaves today**. This is meant to be *inverted, not deleted*, once responses carry a request id.
- `a response for a DIFFERENT key never settles the wrong request` — asserts the bound that does hold, which is the half #94 fixed and the half that carried the user-visible harm.

The upgrade note is scoped accordingly: applications that serialised requests can stop doing so **for different contracts**, with the same-key caveat spelled out. (An earlier draft said this unconditionally, which review correctly flagged as unsafe advice.)

## The real fix

[#106](https://github.com/freenet/freenet-stdlib/issues/106) — a client-generated request id echoed in every terminal response. Appending an optional field to the flatbuffers response tables is backward and forward compatible, and the SDK can fall back to key matching against older nodes during rollout. freenet-core already tracks a `RequestId` internally and drops it before `ClientEventsProxy::send`, so the correlator exists and is simply not exposed.

`Refs #96` rather than `Closes #96` — the reported failure mode is still reachable and the reporter should get the chance to disagree with this call.

## Testing

78 tests pass (76 pre-existing + 2 new). No test was removed or weakened; the diff is additive apart from the version bump.

Refs #96

[AI-assisted - Claude]
