### PR TITLE
docs(client-api): document RegisterDelegate cipher/nonce fields

### DIFF
--- a/rust/src/client_api/client_events.rs
+++ b/rust/src/client_api/client_events.rs
@@ -588,6 +588,21 @@ pub enum DelegateRequest<'a> {
         #[serde(borrow)]
         inbound: Vec<InboundDelegateMsg<'a>>,
     },
+    /// Register a delegate with the node.
+    ///
+    /// `cipher` and `nonce` are retained only for wire-format compatibility
+    /// with older clients (0.8.0 removed the `DEFAULT_CIPHER` /
+    /// `DEFAULT_NONCE` constants that used to be sent here); the node
+    /// discards both values outright and never uses them as key material.
+    /// Since freenet-core#4140 / freenet-core#4146, the node derives the
+    /// delegate's local-scope encryption key itself, via
+    /// `HKDF-SHA256(salt = delegate key, ikm = node KEK)`
+    /// (`SecretsStore::derive_delegate_dek` in freenet-core) — the opposite
+    /// of the secret being "sealed client-side": a client-supplied key is
+    /// rejected precisely because accepting one would let a malicious or
+    /// buggy client substitute a key the node operator does not control.
+    /// Any value is fine here, all-zero bytes included (the fields are
+    /// fixed-size, so "any value" means any bytes, not an empty slice).
     RegisterDelegate {
         delegate: DelegateContainer,
         cipher: [u8; 32],


### PR DESCRIPTION
## Problem

`DelegateRequest::RegisterDelegate` had no rustdoc at all for its `cipher`/`nonce` fields, even though it's the first thing an integrator reads when deciding what to send there (0.8.0 removed the `DEFAULT_CIPHER`/`DEFAULT_NONCE` constants that used to answer that question).

The issue also flagged `RegisterDelegateWithPredecessors`'s doc as actively wrong (it claimed secrets are "sealed client-side"). Checking current `main`: that variant was already removed entirely in 0.9.0 as a security fix (freenet-core#5199 / freenet-core#5198 — its `origin_contract` attestation was forgeable), so there's no misleading text left to correct there.

## Approach

Added rustdoc to `RegisterDelegate` explaining that `cipher`/`nonce` are kept only for wire-format compatibility and discarded by the node, which derives the delegate's DEK itself via `HKDF-SHA256(salt = delegate key, ikm = node KEK)` (`SecretsStore::derive_delegate_dek` in freenet-core, since freenet-core#4140 / freenet-core#4146) — the opposite of client-side sealing, and the reason a client-supplied key is rejected (accepting one would let a malicious/buggy client substitute a key the node operator doesn't control). Cross-checked the derivation and discard behavior directly against `freenet-core`'s `secrets_store/store.rs` and its recent doc-correction commit (`98f358b42`, freenet-core#5472) to keep the wording consistent between repos.

## Testing

Docs-only change; `cargo build -p freenet-stdlib`, `cargo fmt --check`, and `cargo clippy -p freenet-stdlib --all-targets` all clean.

Closes freenet/freenet-stdlib#97

[AI-assisted - Claude]