### PR TITLE
feat(delegate): report whether a subscribe actually pinned the contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ never arrives. On a payment address that is money. See freenet-core#5565.
 node holds state for the contract and has recorded the delegate's interest.
 Under demand-driven hosting **no subscription of any kind is an absolute pin**,
 and a delegate subscription is weaker still: it registers notification interest
-only, contributes **no hosting demand**, and so does not affect eviction ordering
-at all — unlike a client subscription, which is a ranking dimension. The name
+only. On freenet-core as it stands (pre-#4669) it contributes **no hosting
+demand**, and so does not affect eviction ordering at all — unlike a client
+subscription, which is a ranking dimension. freenet-core#5493 implements #4669
+and is open now, so that is current behaviour rather than a fixed property. The name
 describes a live subscription, not a retained one. `NotPinned` is correspondingly
 retryable, and clears as soon as the node holds the state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,27 @@
 
 ## [Unreleased]
 
-### Added — a delegate can learn whether its subscribe actually pinned
+### Added — a delegate can learn whether its subscribe has anything to fire on
 
-`DelegateCtx::subscribe_contract`'s doc now describes at length that a subscribe
-may register no demand, and that **a delegate cannot detect which it got**. This
-adds the way to detect it.
+`true` from `subscribe_contract` means "the node accepted the registration", and
+says nothing about whether the node holds the contract. A node that knows the
+contract's code but holds no state for it registers the interest and returns
+`true`, identically to one that holds it — which is the ordinary situation at
+startup, before the node has fetched the contract. The delegate believes it has
+a live subscription and does not, and the only signal is a notification that
+never arrives. On a payment address that is money. See freenet-core#5565.
 
-`true` from `subscribe_contract` means "the node accepted the registration", not
-"the contract is pinned". A registration accepted without durable demand is
-reported identically to one that pinned, so the delegate believes it holds
-durable interest and does not — the contract stays evictable and notifications
-later stop at a moment the delegate never observes. On a payment address that is
-money. See freenet-core#5565.
-
-- `DelegateCtx::subscribe_contract_checked(&[u8; 32]) -> Result<SubscribeOutcome, i32>`
+- `DelegateCtx::subscribe_contract_checked(&[u8; 32]) -> Result<SubscribeOutcome, i64>`
 - `SubscribeOutcome` — `Pinned`, `NotPinned`, or `Unrecognized(i64)`.
   `is_pinned()` is true only for `Pinned`: an outcome a given build cannot
-  interpret is not evidence of a pin.
+  interpret is not evidence either way.
+
+**`Pinned` is a statement about now, not a durability promise.** It means the
+node holds state for the contract and has recorded the delegate's interest.
+Under demand-driven hosting **no subscription of any kind is an absolute pin** —
+a subscribed contract is ordered last for eviction, not exempt from it — so the
+name describes a live subscription, not a retained one. `NotPinned` is
+correspondingly retryable, and it clears as soon as the node holds the state.
 
 `subscribe_contract` is left **behaviourally unchanged**, deliberately. Altering
 what it returns would change the behaviour of already-deployed delegate WASM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased]
 
+### Added — a delegate can learn whether its subscribe actually pinned
+
+`DelegateCtx::subscribe_contract`'s doc now describes at length that a subscribe
+may register no demand, and that **a delegate cannot detect which it got**. This
+adds the way to detect it.
+
+`true` from `subscribe_contract` means "the node accepted the registration", not
+"the contract is pinned". A registration accepted without durable demand is
+reported identically to one that pinned, so the delegate believes it holds
+durable interest and does not — the contract stays evictable and notifications
+later stop at a moment the delegate never observes. On a payment address that is
+money. See freenet-core#5565.
+
+- `DelegateCtx::subscribe_contract_checked(&[u8; 32]) -> Result<SubscribeOutcome, i32>`
+- `SubscribeOutcome` — `Pinned`, `NotPinned`, or `Unrecognized(i64)`.
+  `is_pinned()` is true only for `Pinned`: an outcome a given build cannot
+  interpret is not evidence of a pin.
+
+`subscribe_contract` is left **behaviourally unchanged**, deliberately. Altering
+what it returns would change the behaviour of already-deployed delegate WASM.
+
+**This is not a wire-format change.** It adds a host function and a plain Rust
+type, so it consumes no bincode variant tag and cannot shift one — additive in
+both directions, which a new enum variant would not be. A delegate that does not
+import it is unaffected; one that does, on a node too old to provide it, fails to
+**instantiate** with a named missing-import error rather than failing
+mid-protocol at decode. Same reasoning as `list_subscriptions`.
+
+Note this does **not** duplicate `list_subscriptions`: that reads the
+subscription set, which contains accepted-but-unpinned registrations, so
+introspection answers "what did I register?" and this answers "what actually got
+pinned?".
+
+The two outcome discriminants (`Pinned = 0`, `NotPinned = 1`) are part of the
+host ABI once a node returns them, and are pinned by test. Requires a node
+providing `__frnt__delegate__subscribe_contract_checked` in the
+`freenet_delegate_contracts` namespace. **No released node does yet** — the host
+half is freenet-core#5565.
+
 ### Added
 
 - **`OutboundDelegateMsg::UnsubscribeContractRequest` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,19 @@ never arrives. On a payment address that is money. See freenet-core#5565.
 
 **`Pinned` is a statement about now, not a durability promise.** It means the
 node holds state for the contract and has recorded the delegate's interest.
-Under demand-driven hosting **no subscription of any kind is an absolute pin** —
-a subscribed contract is ordered last for eviction, not exempt from it — so the
-name describes a live subscription, not a retained one. `NotPinned` is
-correspondingly retryable, and it clears as soon as the node holds the state.
+Under demand-driven hosting **no subscription of any kind is an absolute pin**,
+and a delegate subscription is weaker still: it registers notification interest
+only, contributes **no hosting demand**, and so does not affect eviction ordering
+at all — unlike a client subscription, which is a ranking dimension. The name
+describes a live subscription, not a retained one. `NotPinned` is correspondingly
+retryable, and clears as soon as the node holds the state.
+
+**This check happens at subscribe time and nowhere else**, so a subscription that
+was live can quietly stop being so. Re-checking without a UI attached needs a way
+to run later: `DelegateCtx::schedule_wakeup` (freenet-stdlib#82, same release) is
+that mechanism. Neither change alone closes the scenario in freenet-core#5565 —
+this one lets a delegate learn the truth, and that one lets it ask again. Do not
+read `Pinned` as fire-and-forget.
 
 `subscribe_contract` is left **behaviourally unchanged**, deliberately. Altering
 what it returns would change the behaviour of already-deployed delegate WASM.

--- a/rust/src/delegate_host.rs
+++ b/rust/src/delegate_host.rs
@@ -162,9 +162,11 @@ pub enum SubscribeOutcome {
     /// This is a statement about *now*, not a durability promise. Under
     /// demand-driven hosting **no subscription of any kind is an absolute
     /// pin**, and a delegate subscription is weaker still: it registers
-    /// notification interest only. It contributes **no hosting demand**, so it
-    /// does not affect eviction ordering at all — unlike a client subscription,
-    /// which is a ranking dimension. A delegate must not read this as "the node
+    /// notification interest only. On freenet-core as it stands (pre-#4669) it
+    /// contributes **no hosting demand**, so it does not affect eviction
+    /// ordering at all — unlike a client subscription, which is a ranking
+    /// dimension. freenet-core#5493 implements #4669 and is open now, so treat
+    /// the "no demand" half as current behaviour rather than a fixed property. A delegate must not read this as "the node
     /// will keep this contract for me"; it means the subscription is not
     /// vacuous today.
     Pinned,

--- a/rust/src/delegate_host.rs
+++ b/rust/src/delegate_host.rs
@@ -143,8 +143,8 @@ const _: () = assert!(MAX_SUBSCRIPTION_LIST_BYTES % 32 == 0);
 /// Returned by
 /// [`DelegateCtx::subscribe_contract_checked`](DelegateCtx::subscribe_contract_checked).
 /// It exists because `Result<(), _>` has only two states and the subscribe path
-/// has three: it can pin, it can register for notifications without pinning, or
-/// it can fail. Reusing `Err` for the middle case is wrong — delegates
+/// has three: it can register against state the node holds, it can register
+/// against nothing, or it can fail. Reusing `Err` for the middle case is wrong — delegates
 /// legitimately subscribe before the node has settled, and a usually-transient
 /// condition surfacing as a hard failure would break working delegates today.
 ///
@@ -156,17 +156,25 @@ const _: () = assert!(MAX_SUBSCRIPTION_LIST_BYTES % 32 == 0);
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubscribeOutcome {
-    /// Registered **and** pinned: the node holds durable demand for this
-    /// contract on the delegate's behalf, so it enters the renewal set and is
-    /// exempt from eviction.
+    /// **The node holds state for this contract, and has recorded the
+    /// delegate's interest in it.** Notifications have something to fire on.
+    ///
+    /// This is a statement about *now*, not a durability promise. Under
+    /// demand-driven hosting **no subscription of any kind is an absolute
+    /// pin** — a subscribed contract is ordered last for eviction, not exempt
+    /// from it — so a delegate must not read this as "the node will keep this
+    /// contract for me". It means the subscription is not vacuous today.
     Pinned,
-    /// Registered for notifications, but **not pinned**.
+    /// Registered, but the node holds **no state** for the contract.
     ///
     /// This is the case [`DelegateCtx::subscribe_contract`]'s doc describes at
-    /// length and cannot report: notifications are delivered only while some
-    /// *other* route keeps this node subscribed. Nothing holds the contract on
-    /// the delegate's behalf, so it can be evicted, after which notifications
-    /// stop with no further signal. Treat it as "retry later", not success.
+    /// length and cannot report. The subscription exists, and there is nothing
+    /// for it to fire on: notifications arrive only if some *other* route
+    /// causes this node to hold the contract. The common way to get here is
+    /// subscribing at startup, before the node has fetched the contract.
+    ///
+    /// Treat it as "retry later" — and unlike a pin promise, this one does
+    /// clear: it clears as soon as the node holds the state.
     NotPinned,
     /// The node reported an outcome this build of the stdlib does not know.
     ///
@@ -195,10 +203,15 @@ impl SubscribeOutcome {
         }
     }
 
-    /// Whether the node recorded durable demand for the contract.
+    /// Whether the node holds state for the contract and recorded the
+    /// delegate's interest — i.e. whether the subscription can fire.
     ///
     /// False for [`Self::NotPinned`] and for [`Self::Unrecognized`] — an
-    /// outcome this build cannot interpret is not evidence of a pin.
+    /// outcome this build cannot interpret is not evidence either way, and
+    /// treating it as affirmative is the over-claim this type removes.
+    ///
+    /// Not a durability check. See [`Self::Pinned`]: nothing here promises the
+    /// node keeps the contract.
     pub fn is_pinned(self) -> bool {
         matches!(self, Self::Pinned)
     }
@@ -768,9 +781,12 @@ impl DelegateCtx {
     ///
     /// # The `bool` cannot express the case above
     ///
-    /// Everything this doc says about demand is invisible in the return value:
-    /// `true` means "the node accepted the registration", not "the contract is
-    /// pinned". The `bool` also collapses every negative error code into
+    /// `true` means "the node accepted the registration", and says nothing
+    /// about whether there is anything for the subscription to fire on. A node
+    /// that knows the contract's code but holds no state for it registers the
+    /// interest and returns `true`, identically to one that holds the state —
+    /// which is the ordinary situation at startup, before the node has fetched
+    /// the contract. The `bool` also collapses every negative error code into
     /// `false`, so a transient failure is indistinguishable from an unknown
     /// contract.
     ///
@@ -793,15 +809,19 @@ impl DelegateCtx {
         }
     }
 
-    /// Subscribe to contract updates, and learn whether the subscription
-    /// actually pinned the contract.
+    /// Subscribe to contract updates, and learn whether the node actually
+    /// holds the contract the subscription is against.
     ///
     /// This is [`subscribe_contract`](Self::subscribe_contract) with the
     /// outcome preserved instead of collapsed into a `bool`. Use it whenever
-    /// the delegate's correctness depends on continuing to receive
-    /// notifications — a missed notification on a payment address is money, and
-    /// the failure is otherwise indistinguishable from "nothing has happened
-    /// yet".
+    /// the delegate's correctness depends on the subscription being live — a
+    /// missed notification on a payment address is money, and the failure is
+    /// otherwise indistinguishable from "nothing has happened yet".
+    ///
+    /// [`SubscribeOutcome::NotPinned`] is a *retryable* condition, and it is
+    /// the ordinary one at startup: it clears once the node holds the state.
+    /// It is not a statement about eviction — see [`SubscribeOutcome::Pinned`],
+    /// which is deliberately not a durability promise.
     ///
     /// # Compatibility
     ///

--- a/rust/src/delegate_host.rs
+++ b/rust/src/delegate_host.rs
@@ -161,9 +161,12 @@ pub enum SubscribeOutcome {
     ///
     /// This is a statement about *now*, not a durability promise. Under
     /// demand-driven hosting **no subscription of any kind is an absolute
-    /// pin** — a subscribed contract is ordered last for eviction, not exempt
-    /// from it — so a delegate must not read this as "the node will keep this
-    /// contract for me". It means the subscription is not vacuous today.
+    /// pin**, and a delegate subscription is weaker still: it registers
+    /// notification interest only. It contributes **no hosting demand**, so it
+    /// does not affect eviction ordering at all — unlike a client subscription,
+    /// which is a ranking dimension. A delegate must not read this as "the node
+    /// will keep this contract for me"; it means the subscription is not
+    /// vacuous today.
     Pinned,
     /// Registered, but the node holds **no state** for the contract.
     ///

--- a/rust/src/delegate_host.rs
+++ b/rust/src/delegate_host.rs
@@ -138,6 +138,72 @@ pub const MAX_SUBSCRIPTION_LIST_BYTES: i64 = 32 * 1024;
 // contract ids" above becomes a lie, silently.
 const _: () = assert!(MAX_SUBSCRIPTION_LIST_BYTES % 32 == 0);
 
+/// What a delegate's subscribe request actually achieved.
+///
+/// Returned by
+/// [`DelegateCtx::subscribe_contract_checked`](DelegateCtx::subscribe_contract_checked).
+/// It exists because `Result<(), _>` has only two states and the subscribe path
+/// has three: it can pin, it can register for notifications without pinning, or
+/// it can fail. Reusing `Err` for the middle case is wrong — delegates
+/// legitimately subscribe before the node has settled, and a usually-transient
+/// condition surfacing as a hard failure would break working delegates today.
+///
+/// This type is **not on the wire**. It is the decoded form of a non-negative
+/// `i64` returned by a host function, so adding a variant costs no bincode
+/// variant tag and cannot shift one.
+///
+/// See freenet-core#5565.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscribeOutcome {
+    /// Registered **and** pinned: the node holds durable demand for this
+    /// contract on the delegate's behalf, so it enters the renewal set and is
+    /// exempt from eviction.
+    Pinned,
+    /// Registered for notifications, but **not pinned**.
+    ///
+    /// This is the case [`DelegateCtx::subscribe_contract`]'s doc describes at
+    /// length and cannot report: notifications are delivered only while some
+    /// *other* route keeps this node subscribed. Nothing holds the contract on
+    /// the delegate's behalf, so it can be evicted, after which notifications
+    /// stop with no further signal. Treat it as "retry later", not success.
+    NotPinned,
+    /// The node reported an outcome this build of the stdlib does not know.
+    ///
+    /// A newer node may report an outcome added after this delegate was
+    /// compiled. Treating it as [`Self::Pinned`] would reintroduce exactly the
+    /// silent over-claim this type exists to remove, so it is surfaced.
+    Unrecognized(i64),
+}
+
+impl SubscribeOutcome {
+    /// Discriminant for [`Self::Pinned`] on the host-function return channel.
+    pub const CODE_PINNED: i64 = 0;
+    /// Discriminant for [`Self::NotPinned`] on the host-function return channel.
+    pub const CODE_NOT_PINNED: i64 = 1;
+
+    /// Decode a non-negative host return code.
+    ///
+    /// Negative codes are host **errors** and never reach here; the caller
+    /// separates them first. An unrecognized non-negative code becomes
+    /// [`Self::Unrecognized`] rather than being folded into a known outcome.
+    pub fn from_code(code: i64) -> Self {
+        match code {
+            Self::CODE_PINNED => Self::Pinned,
+            Self::CODE_NOT_PINNED => Self::NotPinned,
+            other => Self::Unrecognized(other),
+        }
+    }
+
+    /// Whether the node recorded durable demand for the contract.
+    ///
+    /// False for [`Self::NotPinned`] and for [`Self::Unrecognized`] — an
+    /// outcome this build cannot interpret is not evidence of a pin.
+    pub fn is_pinned(self) -> bool {
+        matches!(self, Self::Pinned)
+    }
+}
+
 // ============================================================================
 // Host function declarations (WASM only)
 // ============================================================================
@@ -211,6 +277,14 @@ extern "C" {
     ) -> i64;
     /// Subscribe to contract updates. Returns 0 on success, or negative error code (i64).
     fn __frnt__delegate__subscribe_contract(id_ptr: i64, id_len: i32) -> i64;
+
+    /// Subscribe and report the *outcome*, not just success/failure.
+    ///
+    /// Returns a non-negative [`SubscribeOutcome`] discriminant, or a negative
+    /// error code. Distinct from `__frnt__delegate__subscribe_contract`, whose
+    /// `i64` is collapsed to a `bool` by its wrapper and so cannot express an
+    /// outcome that is neither success nor failure. See freenet-core#5565.
+    fn __frnt__delegate__subscribe_contract_checked(id_ptr: i64, id_len: i32) -> i64;
     /// Byte length of this delegate's serialized subscription list — always a
     /// multiple of 32, and never more than [`MAX_SUBSCRIPTION_LIST_BYTES`].
     /// Returns the count to allocate, or a negative error code (i64). Zero
@@ -691,6 +765,20 @@ impl DelegateCtx {
     /// Returns `true` on success, `false` if the contract is unknown or on
     /// error. Note that the contract must already be in the node's local store;
     /// subscribing does not fetch it.
+    ///
+    /// # The `bool` cannot express the case above
+    ///
+    /// Everything this doc says about demand is invisible in the return value:
+    /// `true` means "the node accepted the registration", not "the contract is
+    /// pinned". The `bool` also collapses every negative error code into
+    /// `false`, so a transient failure is indistinguishable from an unknown
+    /// contract.
+    ///
+    /// [`subscribe_contract_checked`](Self::subscribe_contract_checked) reports
+    /// the outcome instead, and is what a delegate should use when its
+    /// correctness depends on continuing to receive notifications. This method
+    /// is deliberately left behaviourally unchanged, because altering what it
+    /// returns would change the behaviour of already-deployed delegate WASM.
     pub fn subscribe_contract(&mut self, instance_id: &[u8; 32]) -> bool {
         #[cfg(target_family = "wasm")]
         {
@@ -702,6 +790,68 @@ impl DelegateCtx {
         {
             let _ = instance_id;
             false
+        }
+    }
+
+    /// Subscribe to contract updates, and learn whether the subscription
+    /// actually pinned the contract.
+    ///
+    /// This is [`subscribe_contract`](Self::subscribe_contract) with the
+    /// outcome preserved instead of collapsed into a `bool`. Use it whenever
+    /// the delegate's correctness depends on continuing to receive
+    /// notifications — a missed notification on a payment address is money, and
+    /// the failure is otherwise indistinguishable from "nothing has happened
+    /// yet".
+    ///
+    /// # Compatibility
+    ///
+    /// This is a **host function**, not a wire-format variant, so it costs no
+    /// bincode variant tag and is additive in both directions:
+    ///
+    /// - A delegate that does not call it is completely unaffected; host
+    ///   imports resolve by name at module instantiation, so an unimported
+    ///   function costs nothing.
+    /// - A delegate that *does* call it, on a node too old to provide it, fails
+    ///   to **instantiate** with a named missing-import error — loudly, at load
+    ///   time, before the delegate has touched any state. A wire variant
+    ///   instead fails mid-protocol at bincode decode, with no way for the
+    ///   delegate to have checked first.
+    ///
+    /// Requires a node providing `__frnt__delegate__subscribe_contract_checked`
+    /// in the `freenet_delegate_contracts` namespace. No released node does
+    /// yet; the host half is freenet-core#5565.
+    ///
+    /// # Errors
+    ///
+    /// `Err(code)` carries the negative host error code and means the
+    /// subscription did not happen at all. A call that succeeded but did not
+    /// pin is `Ok(SubscribeOutcome::NotPinned)`, **not** an error — collapsing
+    /// those two is the defect this method exists to fix.
+    ///
+    /// Off-WASM this always returns `Err(ERR_NOT_IN_PROCESS)` rather than a
+    /// plausible-looking success, so a host-side test cannot read an outcome
+    /// out of a stub that never subscribed to anything.
+    pub fn subscribe_contract_checked(
+        &mut self,
+        instance_id: &[u8; 32],
+    ) -> Result<SubscribeOutcome, i32> {
+        #[cfg(target_family = "wasm")]
+        {
+            let code = unsafe {
+                __frnt__delegate__subscribe_contract_checked(instance_id.as_ptr() as i64, 32)
+            };
+            if code < 0 {
+                // Clamp rather than truncate: an i64 error code outside i32
+                // range is a host bug, and `as i32` would silently alias it
+                // onto a different, meaningful code.
+                return Err(i32::try_from(code).unwrap_or(i32::MIN));
+            }
+            Ok(SubscribeOutcome::from_code(code))
+        }
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let _ = instance_id;
+            Err(error_codes::ERR_NOT_IN_PROCESS)
         }
     }
 
@@ -1237,6 +1387,73 @@ mod list_subscriptions_guard_tests {
             Ok(288),
             "the import contract requires ERR_BUFFER_TOO_SMALL rather than \
              truncation, so a short write means the set shrank"
+        );
+    }
+}
+
+#[cfg(test)]
+mod subscribe_outcome_tests {
+    use super::*;
+
+    #[test]
+    fn known_codes_decode_to_their_outcomes() {
+        assert_eq!(
+            SubscribeOutcome::from_code(SubscribeOutcome::CODE_PINNED),
+            SubscribeOutcome::Pinned
+        );
+        assert_eq!(
+            SubscribeOutcome::from_code(SubscribeOutcome::CODE_NOT_PINNED),
+            SubscribeOutcome::NotPinned
+        );
+    }
+
+    /// The two discriminants are part of the host ABI. Changing either
+    /// reassigns the meaning of a value already returned by deployed nodes, so
+    /// they are pinned rather than left to whatever order the enum happens to
+    /// be written in.
+    #[test]
+    fn outcome_codes_are_pinned() {
+        assert_eq!(SubscribeOutcome::CODE_PINNED, 0);
+        assert_eq!(SubscribeOutcome::CODE_NOT_PINNED, 1);
+    }
+
+    /// An outcome added by a newer node must not be read as a pin. This is the
+    /// whole point of the type: the failure being removed is a delegate
+    /// concluding it holds durable interest when it does not.
+    #[test]
+    fn an_unknown_outcome_is_not_read_as_pinned() {
+        let future = SubscribeOutcome::from_code(7);
+        assert_eq!(future, SubscribeOutcome::Unrecognized(7));
+        assert!(
+            !future.is_pinned(),
+            "an outcome this build cannot interpret must never report as pinned"
+        );
+    }
+
+    #[test]
+    fn only_pinned_reports_pinned() {
+        assert!(SubscribeOutcome::Pinned.is_pinned());
+        assert!(!SubscribeOutcome::NotPinned.is_pinned());
+        assert!(!SubscribeOutcome::Unrecognized(1_000).is_pinned());
+    }
+
+    /// Off-WASM the host function does not exist, so the stub must report an
+    /// error and never a plausible-looking outcome. A stub returning
+    /// `Ok(Pinned)` would let a host-side test read a pin out of a call that
+    /// subscribed to nothing — the same "absence reported as fact" defect the
+    /// method exists to remove, reintroduced in the test harness. This mirrors
+    /// `list_subscriptions_off_wasm_is_an_error_not_an_empty_list`.
+    #[test]
+    fn the_off_wasm_stub_reports_an_error_not_an_outcome() {
+        // SAFETY: off-WASM every method on this handle is a stub that touches
+        // no runtime state; the safety contract concerns the WASM execution
+        // environment, which does not exist in a host-side test.
+        let mut ctx = unsafe { DelegateCtx::__new() };
+        let result = ctx.subscribe_contract_checked(&[0u8; 32]);
+        assert_eq!(
+            result,
+            Err(error_codes::ERR_NOT_IN_PROCESS),
+            "the off-WASM stub must not fabricate a subscribe outcome"
         );
     }
 }

--- a/rust/src/delegate_host.rs
+++ b/rust/src/delegate_host.rs
@@ -824,7 +824,12 @@ impl DelegateCtx {
     /// # Errors
     ///
     /// `Err(code)` carries the negative host error code and means the
-    /// subscription did not happen at all. A call that succeeded but did not
+    /// subscription did not happen at all. It is an `i64`, matching both the
+    /// host function's own return type and
+    /// [`list_subscriptions`](Self::list_subscriptions), rather than narrowing
+    /// to `i32`: the codes in [`error_codes`] all fit in `i32`, but a narrowing
+    /// conversion has to decide what to do with one that does not, and every
+    /// available answer invents a code the host never sent. A call that succeeded but did not
     /// pin is `Ok(SubscribeOutcome::NotPinned)`, **not** an error — collapsing
     /// those two is the defect this method exists to fix.
     ///
@@ -834,24 +839,21 @@ impl DelegateCtx {
     pub fn subscribe_contract_checked(
         &mut self,
         instance_id: &[u8; 32],
-    ) -> Result<SubscribeOutcome, i32> {
+    ) -> Result<SubscribeOutcome, i64> {
         #[cfg(target_family = "wasm")]
         {
             let code = unsafe {
                 __frnt__delegate__subscribe_contract_checked(instance_id.as_ptr() as i64, 32)
             };
             if code < 0 {
-                // Clamp rather than truncate: an i64 error code outside i32
-                // range is a host bug, and `as i32` would silently alias it
-                // onto a different, meaningful code.
-                return Err(i32::try_from(code).unwrap_or(i32::MIN));
+                return Err(code);
             }
             Ok(SubscribeOutcome::from_code(code))
         }
         #[cfg(not(target_family = "wasm"))]
         {
             let _ = instance_id;
-            Err(error_codes::ERR_NOT_IN_PROCESS)
+            Err(error_codes::ERR_NOT_IN_PROCESS as i64)
         }
     }
 
@@ -1430,6 +1432,27 @@ mod subscribe_outcome_tests {
         );
     }
 
+    /// The type must be re-exported from the prelude. `use
+    /// freenet_stdlib::prelude::*` is what a delegate writes, and the whole
+    /// point of this type is to be matched on — needing a second, differently
+    /// shaped import for the match arms would be a papercut on every consumer.
+    ///
+    /// The path is named in full, deliberately. A `use crate::prelude::*` here
+    /// would prove nothing: this module already has `use super::*` in scope, so
+    /// the name resolves whether or not the prelude re-exports it, and the test
+    /// passes with the re-export deleted. Verified — the first version of this
+    /// test did exactly that.
+    #[test]
+    fn the_type_is_re_exported_from_the_prelude() {
+        let outcome = crate::prelude::SubscribeOutcome::from_code(
+            crate::prelude::SubscribeOutcome::CODE_NOT_PINNED,
+        );
+        assert!(matches!(
+            outcome,
+            crate::prelude::SubscribeOutcome::NotPinned
+        ));
+    }
+
     #[test]
     fn only_pinned_reports_pinned() {
         assert!(SubscribeOutcome::Pinned.is_pinned());
@@ -1452,7 +1475,7 @@ mod subscribe_outcome_tests {
         let result = ctx.subscribe_contract_checked(&[0u8; 32]);
         assert_eq!(
             result,
-            Err(error_codes::ERR_NOT_IN_PROCESS),
+            Err(error_codes::ERR_NOT_IN_PROCESS as i64),
             "the off-WASM stub must not fabricate a subscribe outcome"
         );
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,7 +40,7 @@ pub mod prelude {
     pub use crate::contract_interface::*;
     pub use crate::delegate_host::{
         decode_contract_id_list, decode_secret_key_list, encode_contract_id_list,
-        encode_secret_key_list, error_codes, DelegateCtx,
+        encode_secret_key_list, error_codes, DelegateCtx, SubscribeOutcome,
     };
     pub use crate::delegate_interface::wasm_interface::DelegateInterfaceResult;
     pub use crate::delegate_interface::*;


### PR DESCRIPTION
## Problem

`DelegateCtx::subscribe_contract` answers a three-state question with a `bool`.

`true` means **"the node accepted the registration"**, not "the contract is pinned". A registration accepted without registering durable demand — the node holds no state for the contract, or a pin cap was hit — is reported identically to one that pinned. The delegate then believes it holds durable interest and does not: the contract is not exempt from eviction, so notifications stop arriving at a moment the delegate never observes.

From the consumer case in freenet-core#5565: *a seller whose 51st order silently is not pinned misses the payment notification, and that failure is indistinguishable from "the buyer has not paid yet."* Silent under-delivery of a payment notification is money.

The `bool` is lossy twice over — it also collapses every negative host error code into `false`, so a transient failure is indistinguishable from an unknown contract.

## This is deliberately NOT a wire-format change

freenet-core#5565 states that fixing this "needs a wire change" because `SubscribeContractResponse.result` is `Result<(), String>` with no third outcome. **That is true of the V1 message path and not true of the fix**, because the V2 path is already a host function whose return channel is an `i64`:

```rust
fn __frnt__delegate__subscribe_contract(id_ptr: i64, id_len: i32) -> i64;
```

The information channel is already wide enough. What discards it is the wrapper, `result == 0` into a `bool`.

So this adds a host function and a plain Rust type. It consumes **no bincode variant tag** and cannot shift one. That matters for the release this belongs to: it does not compete with freenet-stdlib#82 or #98 for a tag, and it cannot be the thing that breaks a deployed delegate.

## Why a host function rather than a new enum variant

Both were available. The host function has the strictly better failure mode, and the difference is not stylistic:

| | old peer → new peer | new peer → old peer |
|---|---|---|
| **new enum variant** | fine, existing tags unchanged | **hard bincode decode error**, mid-protocol, unpreventable |
| **new host function** | delegate that does not import it is unaffected | fails to **instantiate**, named missing-import, at load time |

A new inbound variant is only safe if the host sends it *exclusively* in reply to something an older delegate cannot have sent — a property of the host implementation, not of the wire format, and therefore something a future change can silently violate. A host import cannot be gotten wrong that way: name resolution at instantiation either succeeds or fails loudly, before the delegate has touched any state.

This is the same argument #98 makes for `list_subscriptions`, applied to the same surface.

## `list_subscriptions` does NOT subsume this

freenet-core#5565 offers two options and prefers option 2, a delegate-visible pin-state query, as "subsuming" option 1. **It does not**, and the two should not be closed as duplicates of each other.

freenet-stdlib#98's `DelegateCtx::list_subscriptions` reads freenet-core's `DELEGATE_SUBSCRIPTIONS` (`crates/core/src/wasm_runtime/native_api.rs:41-43`). A registration that was **accepted but not pinned is in that map** — it is inserted unconditionally once the contract's code resolves, with no pin check. So a delegate that subscribed, was not pinned, and then asked what it is subscribed to would be told it *is* subscribed. The same over-claim, one call later.

Introspection answers **"what did I register?"**. This PR answers **"what actually got pinned?"**. Only the second is the question #5565 asks, and no amount of reading the subscription set can reconstruct it, because the distinction is not recorded there.

They compose: `list_subscriptions` tells a delegate what it holds after a restart; `subscribe_contract_checked` tells it whether a given registration means anything durable. Neither replaces the other.

## Approach

- `DelegateCtx::subscribe_contract_checked(&[u8; 32]) -> Result<SubscribeOutcome, i32>`
- `SubscribeOutcome` — `Pinned`, `NotPinned`, `Unrecognized(i64)`, `#[non_exhaustive]`.

`Err` means the subscription did not happen at all. A call that succeeded but did not pin is `Ok(SubscribeOutcome::NotPinned)`, **not** an error — reusing `Err` for it is what the issue rules out, because delegates legitimately subscribe before the node settles and a usually-transient condition surfacing as a hard failure would break River today.

`is_pinned()` is true **only** for `Pinned`. A newer node may report an outcome added after a given delegate was compiled; folding that into `Pinned` would reintroduce precisely the silent over-claim this type exists to remove, so it surfaces as `Unrecognized` and reads as not-pinned.

`subscribe_contract` is left **behaviourally unchanged**, deliberately. Returning a new code from it would change what already-deployed delegate WASM observes — `result == 0` would turn a soft success into a hard `false`. Its doc comment now states the loss instead.

## Verification

Run against the gate CI actually applies, plus a stricter one:

- `cargo test --features contract,net,testing,trace` — **102 passed, 0 failed** (97 before), doc-tests 1 passed
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` — clean (CI's exact invocation)
- `cargo build --target wasm32-unknown-unknown --features contract` — succeeds
- `cargo fmt --check` — clean

**The guards were made to fail before they were trusted to pass.** A test that runs can still be one that cannot fail:

| Mutation | Result |
|---|---|
| `from_code`'s unknown arm folded into `Pinned` | `an_unknown_outcome_is_not_read_as_pinned` **fails** ✓ |
| deliberate compile error inserted in the `cfg(target_family = "wasm")` branch | build **fails** ✓ — confirming that branch is genuinely compiled, not silently excluded |

The second check is here because host `cargo test` never reaches the WASM branch; #98 found twelve tests in this crate that had never executed for exactly that reason.

The off-WASM stub returns `Err(ERR_NOT_IN_PROCESS)`, never a plausible-looking outcome, and that is asserted — a stub returning `Ok(Pinned)` would let a host-side test read a pin out of a call that subscribed to nothing.

## Host half

freenet-core#5565. **No released node provides `__frnt__delegate__subscribe_contract_checked` yet**, and by the stdlib-first rule it cannot until this publishes. Core currently registers five functions in the `freenet_delegate_contracts` namespace (`crates/core/src/wasm_runtime/engine/wasmtime_engine.rs:2048-2113`); this adds a sixth.

Note for the host implementer: on current core `main`, both the V1 and V2 subscribe paths validate only that the contract's *code* is registered (`lookup_key` / `resolve_contract_key` → `code_hash_from_id`). Neither checks that state is held. So `NotPinned` is the correct answer for a contract whose code is known but which the node does not actually hold — which is the common case at node startup, not an exotic one.

## Scope

This does not address freenet-core#5566 (contract-request truncation). That issue's driving scenario does not reproduce on current `main` — see the note posted there.

[AI-assisted - Claude]
