### PR TITLE
docs: record what is actually safe to change on the delegate wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   delegate namespaces), but a deadline bakes the delegate's reading of it into a
   value only the host can act on.
 
+  Also records that resolving a conflict in a **test module** by keeping both
+  sides is safe for the content and not for the delimiters — a closing brace or
+  a `#[cfg(test)]` can sit in shared context and be dropped, and a lost
+  `#[cfg(test)]` compiles fine while silently removing the module from the run.
+
   Linked from CONTRIBUTING.md, and at the repo root rather than `docs/` because
   a bare `docs` line in `.gitignore` makes that directory untracked and
   `ci.yml`'s `paths-ignore` skips it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- **`WIRE-FORMAT.md`** — what is safe to change on the host↔delegate wire and
+  what is not, established by running bincode rather than by reading its docs.
+  Records three results that contradict the common intuition: appending an enum
+  variant and appending a struct field break in *opposite* directions;
+  `#[non_exhaustive]` has **no effect** on the wire (byte-identical output) and
+  is purely a `match` attribute; and `#[serde(other)]` **does** absorb an unknown
+  tag in bincode 1.x, converting a clean decode error into silent corruption of
+  whatever follows it — though only once the unknown variant carries a payload,
+  which is exactly why it misleads.
+
+  Also covers rebasing a stacked branch after the PR below it is **squash**
+  merged (a plain `git rebase origin/main` replays the whole merged change —
+  use `--onto`), that a **stacked PR runs none of the Rust CI jobs** here
+  because `ci.yml` triggers only on PRs targeting `main`, and why a delegate
+  should prefer a relative delay to an absolute deadline: it *can* read a clock
+  (`freenet_time::__frnt__time__utc_now` is registered on the same linker as the
+  delegate namespaces), but a deadline bakes the delegate's reading of it into a
+  value only the host can act on.
+
+  Linked from CONTRIBUTING.md, and at the repo root rather than `docs/` because
+  a bare `docs` line in `.gitignore` makes that directory untracked and
+  `ci.yml`'s `paths-ignore` skips it.
+
 ### Added — a delegate can learn whether its subscribe has anything to fire on
 
 `true` from `subscribe_contract` means "the node accepted the registration", and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@
 
   Also records that resolving a conflict in a **test module** by keeping both
   sides is safe for the content and not for the delimiters — a closing brace or
-  a `#[cfg(test)]` can sit in shared context and be dropped, and a lost
-  `#[cfg(test)]` compiles fine while silently removing the module from the run.
+  an attribute can sit in shared context and be dropped — with a measured table
+  of what the compiler does and does not catch. Losing `#[cfg(test)]` is *not* a
+  silent-loss mode: every test still runs and the build gets noisier. The
+  dangerous cases are a dropped `#[test]` (absent from the run, green with a
+  smaller count) and a function absorbed wholesale (no warning is possible).
 
   Linked from CONTRIBUTING.md, and at the repo root rather than `docs/` because
   a bare `docs` line in `.gitignore` makes that directory untracked and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ We welcome contributions to Freenet! Here's what you need to know.
 - Run `cargo fmt`, `cargo clippy --all-targets`, and `cargo test` before pushing.
 - **Discard `rust/src/generated/` before committing, unless changing it is the point of your PR.** Building regenerates those FlatBuffers files with whatever `flatc` you have locally, which is usually not the one that produced the checked-in versions — so a build leaves thousands of lines of unrelated churn in your working tree. `git checkout -- rust/src/generated/` clears it. Stage explicit paths rather than `git add -A`, or a toolchain-version downgrade rides into your PR unnoticed and unreviewed.
 - Keep PRs focused — one logical change per PR.
+- **Changing the host↔delegate wire format?** Read [WIRE-FORMAT.md](WIRE-FORMAT.md)
+  first. Appending an enum variant and appending a struct field break in
+  *opposite* directions, `#[non_exhaustive]` does nothing on the wire, and a
+  deployed delegate's decoder cannot be fixed after release.
 
 ## AI-Assisted Contributions
 

--- a/WIRE-FORMAT.md
+++ b/WIRE-FORMAT.md
@@ -239,6 +239,35 @@ your diff, you rebased onto the wrong base — the branch is fine, the rebase wa
 wrong. That is worth knowing in advance, because the natural reading is the
 opposite.
 
+## Resolving a conflict in a test module
+
+Two changes that both append to the same file — two PRs adding variants, or a
+wire change landing beside a doc change — conflict at the same anchors, and the
+resolution is almost always "keep both sides". That is right for the *content*
+and unsafe for the *delimiters*.
+
+Git's conflict regions are line ranges. They do not respect syntactic
+boundaries, so a closing `}` or an attribute can sit in the shared trailing
+context rather than inside either side. Concatenating both sides then drops it.
+Observed while merging two test modules: `mod a_tests { … }`'s closing brace and
+the following `#[cfg(test)]` both vanished, because the brace belonged to the
+context and not to either alternative.
+
+**The compiler caught that one, and it was luck.** An unclosed brace is a hard
+error. A dropped `#[cfg(test)]` alone is not — the module still compiles, and it
+is silently no longer a test module. Nothing fails. That is the same shape as the
+twelve `list_subscriptions` guards that were type-checked and never executed.
+
+So after resolving a conflict that touches tests, do not stop at a green run:
+
+```
+cargo test --features … <module_name>     # per module, and count them
+```
+
+Confirm each affected module still **executes**, by name and by count. A total
+that looks plausible is not evidence; the number you are checking against moved
+too.
+
 ## A stacked PR gets no CI here, silently
 
 Wire changes often arrive as a stack — one PR appends a variant, the next appends

--- a/WIRE-FORMAT.md
+++ b/WIRE-FORMAT.md
@@ -241,24 +241,46 @@ opposite.
 
 ## Resolving a conflict in a test module
 
-Two changes that both append to the same file — two PRs adding variants, or a
-wire change landing beside a doc change — conflict at the same anchors, and the
-resolution is almost always "keep both sides". That is right for the *content*
-and unsafe for the *delimiters*.
+Two changes appending at the same anchor conflict there, and the resolution is
+almost always "keep both sides". That is right for the *content* and unsafe for
+the *delimiters*.
 
 Git's conflict regions are line ranges. They do not respect syntactic
 boundaries, so a closing `}` or an attribute can sit in the shared trailing
-context rather than inside either side. Concatenating both sides then drops it.
+context rather than inside either side, and concatenating both sides drops it.
 Observed while merging two test modules: `mod a_tests { … }`'s closing brace and
 the following `#[cfg(test)]` both vanished, because the brace belonged to the
 context and not to either alternative.
 
-**The compiler caught that one, and it was luck.** An unclosed brace is a hard
-error. A dropped `#[cfg(test)]` alone is not — the module still compiles, and it
-is silently no longer a test module. Nothing fails. That is the same shape as the
-twelve `list_subscriptions` guards that were type-checked and never executed.
+### What the compiler actually catches, measured
 
-So after resolving a conflict that touches tests, do not stop at a green run:
+Do not guess at this — the intuitive answer is wrong in both directions.
+
+| What is lost | Does the test still run? | What you are told |
+|---|---|---|
+| `#[cfg(test)]` on the module | **Yes, all of them** | `cargo build` warns (`unused import`) — the module now compiles into the library |
+| `#[test]` on a function | **No** — silently absent from the run | `warning: function … is never used` (dead_code) |
+| The function or `mod` itself, absorbed into a neighbour | **No** | **Nothing.** There is no referent left to warn about |
+| A closing `}` | n/a | Hard error — but only because of where the token happened to sit |
+
+So `#[cfg(test)]` is **not** a silent-loss mode: `#[test]` functions are collected
+by the harness regardless of it, and the attribute governs whether the module
+compiles *outside* test builds, not whether its tests run *inside* one. Losing it
+makes the build noisier, not quieter.
+
+The genuinely dangerous rows are the middle two. A dropped `#[test]` does earn a
+`dead_code` warning, but the **test run itself stays green with a smaller count**,
+and that warning arrives in a wall of build output nobody reads on a green run. A
+function absorbed wholesale earns nothing at all.
+
+The real silent-exclusion mechanism in this repo is a **target** gate, not a test
+gate: the twelve `list_subscriptions` guards sat behind
+`cfg(target_family = "wasm")`, which genuinely excludes them, and CI's wasm32 jobs
+build and lint without executing anything. That is the shape to fear.
+
+### The check
+
+Because the failure is a smaller number rather than a red one:
 
 ```
 cargo test --features … <module_name>     # per module, and count them

--- a/WIRE-FORMAT.md
+++ b/WIRE-FORMAT.md
@@ -1,0 +1,352 @@
+# The delegate wire format: what is safe to change, and what is not
+
+*Not in `docs/` because a bare `docs` line in `.gitignore` makes that directory
+untracked, and CI skips it via `paths-ignore` — a file put there is silently
+never committed.*
+
+The host↔delegate boundary (`InboundDelegateMsg`, `OutboundDelegateMsg`, and the
+structs they carry) is serialized with **bincode 1.3.3**. Once a delegate WASM is
+built and deployed, its decoder is frozen. You cannot fix a wire mistake in a
+later release, because the thing holding the old expectation is someone else's
+compiled artifact.
+
+This note records what bincode actually does, established by running it rather
+than by reading its docs — several of these contradict the intuition, and one
+contradicts what its own error strings suggest. Where a rule has an executable
+form, the test is named; prefer changing the test over changing this file.
+
+## The one-line rules
+
+1. **Never append a field to a struct that is already on the wire.**
+2. **Appending an enum variant is safe only in one direction**, and the other
+   direction is a hard failure you must design around, not discover.
+3. **Prefer a host function to a new variant** when the answer is synchronous.
+4. **`#[non_exhaustive]` does nothing on the wire.** It is not a compatibility
+   mechanism. It is a `match` attribute.
+5. **Never reach for `#[serde(other)]` here.** It appears to solve the problem
+   and makes it worse.
+6. **A delegate should not originate an absolute deadline.** It *can* read a
+   clock, but a deadline bakes the delegate's reading of it into a field the
+   host must honour, and a relative delay does not.
+
+## Appending an enum variant
+
+| direction | result |
+|---|---|
+| old sender → new receiver | **fine.** Existing tags are unchanged. |
+| new sender → old receiver | **hard error.** Not a skipped message, not a misparse. |
+
+The error text, for the 9th variant arriving at a receiver that knows 8:
+
+```
+invalid value: integer `8`, expected variant index 0 <= i < 8
+```
+
+It is an `ErrorKind::Custom` produced by serde's derived visitor. It is **not**
+`ErrorKind::InvalidTagEncoding`, despite that variant's description string
+reading "tag for enum is not valid" — bincode constructs that one only for a bad
+`Option` discriminant, in a single place (`bincode-1.3.3/src/de/mod.rs:340`). An
+external reviewer once recommended asserting `InvalidTagEncoding` here; a test
+written to that suggestion would have failed permanently while looking correct.
+
+**The consequence that matters.** A new *inbound* variant is sent by the host, so
+the host can break every deployed delegate the moment it sends one. That is safe
+only if the host sends it **strictly in reply to something an older delegate
+cannot have sent**. `WakeupFired` is safe because only a delegate that emitted
+`ScheduleWakeup` ever receives one. A hypothetical "your run was truncated"
+notice would **not** be safe, because nothing stops the host emitting it to a
+delegate that never opted in.
+
+That opt-in property is a property of the *host implementation*, not of the wire
+format. Nothing here enforces it. If you add an inbound variant, say in the PR
+which host behaviour keeps it safe, and make sure the host half preserves it.
+
+Executable form: `delegate_wire_compat::a_new_variant_does_not_decode_on_an_old_receiver`,
+`::a_hand_built_old_encoder_payload_decodes_into_the_same_variant`.
+
+## Appending a struct field — the dangerous one
+
+Appending an enum variant and appending a struct field break in **opposite**
+directions, and carrying the intuition from one to the other is how this goes
+wrong.
+
+| direction | result |
+|---|---|
+| old bytes → new struct | **hard error**: `io error: unexpected end of file` |
+| new bytes → old struct, struct terminal in its message | silently truncated, no error |
+| new bytes → old struct, **not** terminal | **silent corruption of everything after it** |
+
+The corruption is real and quiet. Encoding `(NewS { a, b, c }, trailing: u32)`
+and decoding as `(OldS { a, b }, u32)` yields the wrong trailing value — the
+appended field's bytes are read as the next field's — with no error anywhere.
+bincode is positional and carries no field names, so there is nothing for a
+decoder to skip.
+
+**`#[serde(default)]` does not help.** It fires only when a self-describing
+format reports a field absent *by name*; bincode just runs out of bytes. That
+`ContractState::size_bytes` carries `#[serde(default)]` makes this easy to
+misread — that attribute protects `serde_json`, not this path.
+
+Note who this hurts: "old bytes → new struct is a hard error" means a delegate
+built against a **newer** stdlib breaks on an **older** node — the ordinary state
+of the world between a stdlib release and the freenet-core bump that consumes it,
+so not an exotic case.
+
+**That one deployment gets bitten twice, and the second bite is the quiet one.**
+The same newer-stdlib delegate on the same older node also *sends* new bytes to
+it, which is the silent-truncation-or-corruption row of the table. The hard error
+is the direction you notice; the corruption is the direction that matters, and
+they arrive together. A document about this wire is not doing its job if it names
+only the loud one.
+
+Prefer a new enum variant over a new field on an existing wire struct: a variant
+is only seen by a peer that asked for it **when the sender guarantees that** (see
+the variant section above — nothing in the format enforces it). A struct field
+has no such option even in principle: it rides along on every message of that
+type, to every peer, whether or not anyone asked. The comparison holds; it is the
+sender's discipline that carries it, not the wire.
+
+Executable form: the `struct_field_wire_compat` module, including
+`node_diagnostics_response_is_terminal_in_its_message`, which pins a terminality
+property that is invisible at the definition site.
+
+## `#[non_exhaustive]` is not a wire mechanism
+
+Encoded bytes are **byte-identical** with and without it, and decode behaviour is
+identical in both directions. It changes nothing at runtime.
+
+What it does is force downstream crates to include a wildcard arm. That is why
+the two enums differ deliberately, and the difference is not stylistic:
+
+- **`InboundDelegateMsg` is `#[non_exhaustive]`.** Its consumers are third-party
+  delegate WASM, which can reasonably ignore a variant it does not recognize —
+  *at the source level*. This buys nothing at the wire level; see above.
+- **`OutboundDelegateMsg` is deliberately not.** freenet-core dispatches it in
+  exhaustive matches with no wildcard, so a new variant is a compile error there
+  until someone handles it. Marking it would let a new variant compile against
+  the host with **no handler**, silently swallowing the delegate's request.
+
+Two honest limits on that argument, both learned the hard way:
+
+- The compile error forces an **arm**, not a working handler. An arm returning
+  `Ok(())` compiles perfectly and is exactly the silent stub in question. This
+  crate proves it: the FlatBuffers encoder has six arms that log and drop.
+- `#[non_exhaustive]` has no effect **inside the defining crate**, which is why
+  the tag map is an exhaustive match here — that is what makes an unpinned
+  variant a compile error rather than a silent omission.
+
+## Do not use `#[serde(other)]`
+
+The common advice is that `#[serde(other)]` only works for self-describing
+formats. **That is wrong for bincode 1.x** — a unit catch-all variant does absorb
+an unknown tag, and the decode "succeeds".
+
+That is worse than the error it replaces, and the precise statement is stronger
+than the loose one, so state it precisely.
+
+The catch-all consumes only the *tag*, never the unknown variant's payload,
+because the receiver has no idea how many bytes that variant carries.
+
+- If the unknown variant is a **unit** variant, there is no payload, nothing
+  after it is misread, and the decode is genuinely clean.
+- The moment the unknown variant carries a **payload**, those bytes are read as
+  whatever comes next in the buffer, silently.
+
+So the failure is conditional on a property of a variant **that does not exist
+yet** — you are betting that nobody ever gives a future variant a field. That is
+exactly why it is unusable: a developer who tries it against a unit variant sees
+it work, concludes the warning is overstated, and ships the bet.
+
+Executable form, in `delegate_wire_compat`:
+`serde_other_does_absorb_an_unknown_tag_in_bincode` (the claim that contradicts
+the common advice), `the_catch_all_silently_corrupts_trailing_data` (the payload
+case), and `the_catch_all_is_clean_for_a_unit_variant` (the case that misleads).
+On mock types, deliberately — the real enums must never grow a catch-all.
+
+Take the hard error.
+
+## Prefer a host function where you can
+
+Where a capability can be expressed either as a wire variant or as a host
+function, the host function has the better failure mode:
+
+| | old peer → new peer | new peer → old peer |
+|---|---|---|
+| new enum variant | fine | hard decode error, **mid-protocol**, unpreventable |
+| new host function | unaffected if not imported | fails to **instantiate**, named missing-import, **at load** |
+
+> **This row is reasoned, not measured — the only such claim in this file.**
+> Every other rule here names a test. The instantiation-failure behaviour is
+> standard WASM linking and there is no reason to doubt it, but freenet-core has
+> no `unknown import` handling or test anywhere, and an attempt to demonstrate it
+> locally failed to link for unrelated reasons. A `wat`-based test is recorded as
+> owed on freenet-core#3972. Until it exists, treat this as the well-founded
+> expectation it is rather than as a verified property — and note that
+> freenet-stdlib#82's design rests on it.
+
+Host functions resolve by name at module instantiation. A delegate that does not
+import one is entirely unaffected. A delegate that does, on a node too old to
+provide it, fails to load with an error naming the missing import — before it has
+touched any state, and in a form a human can act on. Compare a new variant, which
+fails partway through a protocol exchange with no way for the delegate to have
+checked first.
+
+They also cost no tag, so they cannot collide with a concurrent change.
+
+`DelegateCtx::list_subscriptions` and `subscribe_contract_checked` are both this
+shape. Note the tradeoff: a host function's return channel is an `i64`, so design
+it to carry outcomes rather than a `bool` — collapsing it is how
+`subscribe_contract` came to report "registered but not pinned" as success.
+
+## If you are adding a variant
+
+1. Append at the **END**. Never insert, never reorder, never remove.
+2. Add it to `pinned_inbound_tag` / `pinned_outbound_tag` — exhaustive matches,
+   so this is a compile error if you forget.
+3. Bump `INBOUND_VARIANT_COUNT` / `OUTBOUND_VARIANT_COUNT`, and add a value to
+   `every_inbound` / `every_outbound`. The unknown-tag probe fails if you don't.
+4. Say in the PR **which host behaviour makes the new direction safe.**
+5. Bump the crate minor version. Appending to `OutboundDelegateMsg` is
+   source-breaking for downstream exhaustive matches; on a 0.x line that is a
+   minor bump.
+
+**If a tag pin fails, do not update the expected numbers.** Either a variant was
+inserted or reordered — revert it and append instead — or one was removed, which
+renumbers every later tag and needs a deliberate release decision. The
+`RegisterDelegateWithPredecessors` removal in 0.9.0 is the shape of that
+decision: it was appended last specifically so that removing it renumbered
+nothing.
+
+## Rebasing a stacked PR after a squash merge
+
+The lower PR merges as a **squash**, so its commits are not ancestors of `main` —
+only their combined content is, under one new SHA. Your stacked branch still
+carries the originals.
+
+A plain `git rebase origin/main` therefore replays **the whole merged change**
+on top of a `main` that already contains it. Observed on freenet-stdlib#82 after
+#98 merged: the PR went `CONFLICTING` with a diff of **+2022 across 8 files**,
+where its own change is 3 files.
+
+Replay only your own commits:
+
+```bash
+git rebase --onto origin/main <your-commit>^   # or <old base head>
+```
+
+The tell is the diff size. If a rebase leaves you with the lower PR's files in
+your diff, you rebased onto the wrong base — the branch is fine, the rebase was
+wrong. That is worth knowing in advance, because the natural reading is the
+opposite.
+
+## A stacked PR gets no CI here, silently
+
+Wire changes often arrive as a stack — one PR appends a variant, the next appends
+another behind it — because that is the only way to keep each diff reviewable.
+Be aware of what that costs.
+
+`.github/workflows/ci.yml` triggers only on pull requests targeting `main`:
+
+```yaml
+pull_request:
+  branches: [main]
+```
+
+So a PR based on **another PR's branch** runs **none** of the Rust jobs. It does
+not fail. It shows whatever always-on checks exist (`license/cla`) and nothing
+else — one green check, no red ones, which reads as passing and is not. There is
+no red mark anywhere to notice.
+
+The sequence that works:
+
+1. Base the upper PR on the lower one, so its diff shows only its own change.
+2. Verify it locally and **say in the PR that CI has not run**, with the commands
+   and their output. A local run is evidence; it is not the gate.
+3. Merge the lower PR. GitHub retargets the upper one to `main` automatically.
+4. **CI fires then.** Only now is the upper PR mergeable.
+
+Never queue the upper PR before its jobs have actually run. "Not red" is not
+green when nothing was asked.
+
+This is the same defect class the rest of this file is about: a true signal
+answering the wrong question. `license/cla` really did pass. It just says
+nothing about whether the code compiles.
+
+## Time: prefer a delay to a deadline
+
+Relevant to any wire field carrying a deadline, and easy to get wrong in both
+directions.
+
+**A delegate can read a clock.** `freenet_stdlib::time::now()` imports
+`freenet_time::__frnt__time__utc_now`, and freenet-core registers it on the
+**same** `Linker<HostState>` as the four `freenet_delegate_*` namespaces, inside
+the same `register_host_functions`, which both production engine constructors
+call. There is no separate delegate linker and no import allowlist. Core's own
+conformance doc treats this as intended rather than incidental: for a delegate a
+host clock "is unremarkable", because a delegate holds private per-node state, is
+never replicated, and has no merge laws to satisfy. The #5465 host-clock
+deprecation is **contract-only**.
+
+What *is* true, and worth knowing separately: `SystemTime::now()` from `std`
+compiles for `wasm32-unknown-unknown` and then **panics at runtime** — "time not
+implemented on this platform". The clock arrives by host import, not from `std`.
+
+**So prefer a relative delay anyway**, for reasons that have nothing to do with
+availability:
+
+- A deadline bakes the *delegate's* reading of a clock into a value the host must
+  honour. A delay is resolved by the host against its own clock, which is the
+  only clock that can act on it.
+- Wall-clock steps — NTP correction, a manual change — become the host
+  scheduler's business rather than a semantic left undefined on the wire.
+- A delay is strictly more capable: absolute scheduling is `target - now`,
+  expressible in terms of a delay, while a deadline gains nothing a delay lacks.
+- A delegate re-arming a recurring wakeup asks for the same delay again, so it
+  needs no timestamp echoed back to it.
+- `SystemTime` has an encoding hazard a `Duration` does not: a **pre-epoch**
+  value fails to serialize outright (`SystemTime must be later than
+  UNIX_EPOCH`), and that is an error on the *sender*, at a point where the
+  surrounding code may well `unwrap` it.
+
+Both types encode as **u64 seconds LE + u32 nanos**, 12 bytes, so nothing is paid
+for preferring the delay.
+
+### Why a survey of host functions missed the clock
+
+Worth more than the correction itself, because the next person will survey the
+same way.
+
+An earlier draft of this file asserted that a delegate has **no** clock, on the
+strength of enumerating the four `freenet_delegate_*` namespaces and finding
+nothing temporal. The clock is in a fifth namespace, `freenet_time`, which is not
+delegate-prefixed — so the enumeration was bounded by a **naming convention**
+rather than by the actual import surface. An enumeration is only as good as the
+boundary drawn around it.
+
+It is worse than that, and this is the part to remember. The clock is registered
+through **constants** — `conformance::HOST_CLOCK_NAMESPACE` and
+`HOST_CLOCK_IMPORT` — rather than string literals, deliberately, so that core's
+conformance detector cannot drift from the registration. That is a good decision.
+It also means **grepping the engine for `"freenet_time"` does not find the
+registration** — the one hit is a WAT test fixture (`wasmtime_engine.rs:3413`),
+not the `func_wrap` call. The measure that made the registration robust for one
+tool made it invisible to another. If you land on that fixture, it is a thread
+worth pulling rather than a dead end: it exists precisely because the real
+registration is not greppable. If you are surveying what a guest can import, follow the constants, or
+read the linker registration rather than searching for the names it uses.
+
+Do not put a count of host functions in this file. It changes with nearly every
+release, and a stale number in a reference reads as authority.
+
+There is a sharper reason too: **the question has no single answer.** Counting
+stdlib's `fn __frnt__delegate__*` externs gives what a delegate may *import*;
+counting core's `func_wrap` registrations in the same namespaces gives what a
+node *provides*. On one measurement those were 18 and 16, and the gap of 2 was
+exactly the pair added to stdlib with no core half yet.
+
+**The two sides are deliberately out of step**, and permanently so: the
+stdlib-first policy means a wire or ABI addition lands here, is released, and
+only then is implemented in core. Declared therefore always leads provided. A
+count that does not say which side it means is not merely perishable, it is
+ambiguous — and the gap is a normal, healthy state rather than a defect to
+reconcile.

--- a/rust/src/delegate_interface.rs
+++ b/rust/src/delegate_interface.rs
@@ -2121,4 +2121,160 @@ mod delegate_wire_compat {
             );
         }
     }
+
+    // ---------------------------------------------------------------------
+    // `#[serde(other)]` — the one rule in WIRE-FORMAT.md that contradicts the
+    // common advice, so it is the one a future reader will doubt and re-derive.
+    // These three tests are that derivation, kept where it cannot rot.
+    //
+    // Mock types, deliberately: the real enums must never grow a catch-all, so
+    // the property has to be demonstrated on stand-ins.
+    // ---------------------------------------------------------------------
+
+    // The appended variants sit at tag 2, and `OldMsgWithCatchAll` declares
+    // only 0 and 1. That gap is load-bearing: at tag 1 the catch-all's own
+    // declared index, a plain unit variant decodes identically and the
+    // attribute does no work at all — so mocks aligned that way pass with
+    // `#[serde(other)]` deleted, testing nothing. Verified: they did.
+    //
+    // Both cases occur on a real append. The FIRST new variant lands exactly at
+    // the catch-all's index, where the attribute is unnecessary; the SECOND is
+    // out of range, where it is the only thing between a hard error and silent
+    // corruption. The out-of-range case is the one the rule depends on, so it
+    // is the one the mocks must produce.
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum NewMsgWithPayload {
+        First(u32),
+        Second(bool),
+        Appended(String),
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum OldMsgWithCatchAll {
+        First(u32),
+        // Deliberately stops here: real variants 0 only, catch-all at 1. The
+        // appended variants above are at tag 2, which is OUT OF RANGE for this
+        // enum — that gap is what the attribute has to bridge.
+        #[serde(other)]
+        Unknown,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum NewMsgUnitAppended {
+        First(u32),
+        Second(bool),
+        AppendedUnit,
+    }
+
+    /// The mocks' tag gap is asserted, not merely commented — and asserted
+    /// against **the two enums whose alignment actually matters**.
+    ///
+    /// The vacuity condition is precisely: the tag `Appended` encodes to is the
+    /// same as the index `OldMsgWithCatchAll` absorbs into `Unknown`. At that
+    /// index a plain unit variant behaves identically and `#[serde(other)]`
+    /// does no work, so the three tests below stop testing the attribute while
+    /// still passing.
+    ///
+    /// Both numbers are measured from the types rather than written down, so
+    /// this fires whichever side moves — adding a variant to the old enum, or
+    /// removing the filler from the new ones. An earlier version of this guard
+    /// compared against a separate no-attribute copy of the old enum and
+    /// **missed the first case entirely**, because that copy did not move when
+    /// the real one did. A control that can drift from what it controls is not
+    /// a control.
+    ///
+    /// This exists because the alignment has broken **three times** in this
+    /// file, twice at the hands of someone actively fixing it. A comment cannot
+    /// catch the fourth.
+    #[test]
+    fn the_attribute_is_what_bridges_the_gap() {
+        fn tag_of(bytes: &[u8]) -> u32 {
+            u32::from_le_bytes(
+                bytes[..4]
+                    .try_into()
+                    .expect("a bincode enum tag is 4 bytes"),
+            )
+        }
+
+        let appended =
+            tag_of(&bincode::serialize(&NewMsgWithPayload::Appended("x".into())).unwrap());
+
+        // The lowest tag `OldMsgWithCatchAll` absorbs into `Unknown` is its
+        // catch-all index; below it, real variants decode as themselves.
+        let absorbed_from = (0u32..16)
+            .find(|t| {
+                let mut probe = t.to_le_bytes().to_vec();
+                probe.extend_from_slice(&[0u8; 32]);
+                matches!(
+                    bincode::deserialize::<OldMsgWithCatchAll>(&probe),
+                    Ok(OldMsgWithCatchAll::Unknown)
+                )
+            })
+            .expect("OldMsgWithCatchAll must absorb some tag; it has #[serde(other)]");
+
+        assert!(
+            appended > absorbed_from,
+            "`Appended` is at tag {appended} and OldMsgWithCatchAll absorbs from tag \
+             {absorbed_from}: the mocks have re-aligned, so the serde(other) tests below \
+             are vacuous and pass with the attribute deleted. Move `Appended` above the \
+             catch-all index again rather than adjusting this test."
+        );
+    }
+
+    /// Contradicts the usual "self-describing formats only" claim: bincode 1.x
+    /// **does** let `#[serde(other)]` absorb an unknown variant tag.
+    ///
+    /// That is the trap, not a feature — see the next test for why.
+    #[test]
+    fn serde_other_does_absorb_an_unknown_tag_in_bincode() {
+        let encoded = bincode::serialize(&NewMsgWithPayload::Appended("x".into())).unwrap();
+        let decoded: OldMsgWithCatchAll =
+            bincode::deserialize(&encoded).expect("serde(other) absorbs the unknown tag");
+        assert_eq!(decoded, OldMsgWithCatchAll::Unknown);
+    }
+
+    /// The absorption consumes the **tag only**, never the unknown variant's
+    /// payload, so everything after it in the buffer is silently misread.
+    ///
+    /// A hard decode error would have been strictly better: this turns a loud,
+    /// immediate failure into a wrong value with no error anywhere.
+    #[test]
+    fn the_catch_all_silently_corrupts_trailing_data() {
+        let encoded =
+            bincode::serialize(&(NewMsgWithPayload::Appended("hello-future".into()), 4242u32))
+                .unwrap();
+
+        let (variant, trailing): (OldMsgWithCatchAll, u32) =
+            bincode::deserialize(&encoded).expect("decodes, which is the problem");
+
+        assert_eq!(variant, OldMsgWithCatchAll::Unknown);
+        assert_ne!(
+            trailing, 4242,
+            "if this ever equals 4242, serde(other) stopped eating the payload \
+             and this section of WIRE-FORMAT.md needs revisiting"
+        );
+    }
+
+    /// And the reason the trap works: against a **unit** unknown variant there
+    /// is no payload to leave behind, nothing after it is misread, and the
+    /// decode really is clean.
+    ///
+    /// So a developer who tries `#[serde(other)]` on a unit variant sees it
+    /// work and concludes the warning is overstated. The corruption is
+    /// conditional on a property of a variant that does not exist yet — you are
+    /// betting nobody ever gives a future variant a field.
+    #[test]
+    fn the_catch_all_is_clean_for_a_unit_variant() {
+        let encoded = bincode::serialize(&(NewMsgUnitAppended::AppendedUnit, 4242u32)).unwrap();
+
+        let (variant, trailing): (OldMsgWithCatchAll, u32) =
+            bincode::deserialize(&encoded).expect("unit variant leaves nothing behind");
+
+        assert_eq!(variant, OldMsgWithCatchAll::Unknown);
+        assert_eq!(
+            trailing, 4242,
+            "a unit unknown variant must NOT corrupt what follows — this is the \
+             case that misleads, and it is why the rule is unconditional"
+        );
+    }
 }


### PR DESCRIPTION
## Why

The host↔delegate wire is the one surface in this crate that **cannot be fixed after release** — the thing holding the old expectation is someone else's compiled WASM. The rules governing it were, until now, spread across PR bodies and one reviewer's working session.

Three of them contradict a plausible intuition, and were established by **running bincode 1.3.3**, not by reading its documentation. One of them contradicts what bincode's own error strings suggest.

## What is recorded

1. **Appending an enum variant and appending a struct field break in OPPOSITE directions.** A variant is fine old→new and a hard error new→old. A field is a hard error old-bytes→new-struct, and **silently corrupts everything after it** new-bytes→old-struct when the struct is not terminal in its message. Carrying the intuition from one to the other is exactly how this goes wrong. `#[serde(default)]` does not rescue it — bincode is positional and has no field names.

2. **`#[non_exhaustive]` has no effect on the wire.** Encoded bytes are byte-identical with and without it, both directions. It is a `match` attribute, not a compatibility mechanism, and it is routinely mistaken for one — including, previously, by a doc comment in this crate.

3. **`#[serde(other)]` DOES absorb an unknown tag in bincode 1.x.** This contradicts the usual "self-describing formats only" advice, and the apparent success is a trap: the catch-all consumes the *tag* but not the unknown variant's payload, so everything after it is misread. It converts a clean, loud, immediate failure into silent corruption. The note says plainly: take the hard error.

Also recorded, because they are the reasoning a future author needs rather than the facts alone:

- **Why a new inbound variant is only conditionally safe.** The host sends inbound messages, so it can break every deployed delegate the moment it sends a new variant. It is safe only when sent strictly in reply to something an older delegate cannot have sent. `WakeupFired` qualifies; a hypothetical unsolicited "your run was truncated" notice would not. **That is a property of the host implementation, not of the wire format, and nothing enforces it** — so it has to be stated per change.
- **Why a host function is the better shape** where the answer is synchronous: it costs no tag, is opt-in by name resolution, and fails at *instantiation* with a named missing-import rather than mid-protocol at decode.
- **Why the two enums differ deliberately**, with the two honest limits on that argument: the compile error forces an *arm*, not a working handler (this crate has six arms that log and drop), and `#[non_exhaustive]` does nothing inside the defining crate.
- A checklist for adding a variant, ending with: **if a tag pin fails, do not update the expected numbers.**

## Scope

Documentation only — no code, no test, no wire change. New file plus a CHANGELOG entry, so it conflicts with nothing.

Where a rule already has an executable form, the note **names the test rather than restating it** (`delegate_wire_compat::a_new_variant_does_not_decode_on_an_old_receiver`, the `struct_field_wire_compat` module, `node_diagnostics_response_is_terminal_in_its_message`). The tests stay the source of truth; this file is the explanation of why they exist. Findings 2 and 3 above have no test yet — they came out of separate empirical work — and are the parts this file is genuinely carrying on its own.

Deliberately kept off #98 and #82 so it does not re-stale a review those PRs have already been through.

[AI-assisted - Claude]